### PR TITLE
Add `sandboxing` and `embedResources` to the builder override

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,14 +8,15 @@
 
 `ndg` is a way to automatically generate an HTML document containing all the options you use in any set of modules.
 
- This flake exposes a package (`packages.<system>.ndg-builder` a.k.a. `packages.<system>.default`),
- as well as an overlay (`overlays.default`) to allow accessing `ndg-builder` in another nixpkgs instance.
+This flake exposes a package (`packages.<system>.ndg-builder` a.k.a. `packages.<system>.default`),
+as well as an overlay (`overlays.default`) to allow accessing `ndg-builder` in another nixpkgs instance.
 
 ## Usage
 
 You can override the exposed package with the following options:
 
-* `rawModules`: a list of modules containing `options` to document. For example:
+- `rawModules`: a list of modules containing `options` to document. For example:
+
 ```nix
 [
   {
@@ -27,8 +28,10 @@ You can override the exposed package with the following options:
   }
 ]
 ```
-* `specialArgs`: the `specialArgs` to pass through to the `lib.evalModules` call.
-* `evaluatedModules`: the result of `lib.evalModules` applied to a list of modules containing some `options` to document. For example:
+
+- `specialArgs`: the `specialArgs` to pass through to the `lib.evalModules` call.
+- `evaluatedModules`: the result of `lib.evalModules` applied to a list of modules containing some `options` to document. For example:
+
 ```nix
 lib.evalModules {
   modules = [
@@ -42,15 +45,21 @@ lib.evalModules {
   ];
 }
 ```
+
 This includes anything that uses `lib.evalModules` underneath, such as a NixOS, Home Manager, or Nix-Darwin configuration.
 For example, in the context of a flake:
+
 ```
 self.nixosConfigurations.myHost
 ```
-> [!NOTE]
-> `rawModules` and `evaluatedModules` are mutually exclusive.
-* `title`: the title of your documentation page
-* `templatePath`: path to a [pandoc template](https://pandoc.org/MANUAL.html#templates)
-* `styleSheetPath`: path to a Sassy CSS (SCSS) file that will compile to css
-* `codeThemePath`: path to a [pandoc syntax highlighting file](https://pandoc.org/MANUAL.html#syntax-highlighting) (note that it must be JSON with a `.theme` extension)
-* `optionsDocArgs`: additional arguments to pass to the `nixosOptionsDoc` package
+
+> [!NOTE] > `rawModules` and `evaluatedModules` are mutually exclusive.
+
+- `sandboxing`: whether to pass `--sandbox` to pandoc
+- `embedResources`: whether `--self-contained` should be passed to pandoc in
+  order to generate an entirely self-contained HTML document
+- `title`: the title of your documentation page
+- `templatePath`: path to a [pandoc template](https://pandoc.org/MANUAL.html#templates)
+- `styleSheetPath`: path to a Sassy CSS (SCSS) file that will compile to css
+- `codeThemePath`: path to a [pandoc syntax highlighting file](https://pandoc.org/MANUAL.html#syntax-highlighting) (note that it must be JSON with a `.theme` extension)
+- `optionsDocArgs`: additional arguments to pass to the `nixosOptionsDoc` package

--- a/README.md
+++ b/README.md
@@ -53,7 +53,8 @@ For example, in the context of a flake:
 self.nixosConfigurations.myHost
 ```
 
-> [!NOTE] > `rawModules` and `evaluatedModules` are mutually exclusive.
+> [!NOTE]
+> `rawModules` and `evaluatedModules` are mutually exclusive.
 
 - `sandboxing`: whether to pass `--sandbox` to pandoc
 - `embedResources`: whether `--self-contained` should be passed to pandoc in

--- a/pkgs/builder.nix
+++ b/pkgs/builder.nix
@@ -22,8 +22,13 @@
     }
   ],
   specialArgs ? {},
-  evaluatedModules ? lib.evalModules {modules = rawModules; inherit specialArgs;},
+  evaluatedModules ?
+    lib.evalModules {
+      modules = rawModules;
+      inherit specialArgs;
+    },
   title ? "My Option Documentation",
+  sandboxing ? true,
   templatePath ? ./assets/default-template.html,
   styleSheetPath ? ./assets/default-styles.scss,
   codeThemePath ? ./assets/default-syntax.theme,
@@ -53,13 +58,13 @@ in
       # convert pandoc markdown to html using our own template and css files
       # where available. --sandbox is passed for extra security.
       pandoc \
-       --sandbox \
        --from markdown \
        --to html \
        --metadata title="${title}" \
        --toc \
        --standalone \
     ''
+    + optionalString sandboxing ''--sandbox \''
     + optionalString (templatePath != null) ''--template ${templatePath} \''
     + optionalString (styleSheetPath != null) ''--css ${ndg-stylesheet.override {inherit styleSheetPath;}} \''
     + optionalString (codeThemePath != null) ''--highlight-style ${codeThemePath} \''

--- a/pkgs/builder.nix
+++ b/pkgs/builder.nix
@@ -29,6 +29,7 @@
     },
   title ? "My Option Documentation",
   sandboxing ? true,
+  embedResources ? false,
   templatePath ? ./assets/default-template.html,
   styleSheetPath ? ./assets/default-styles.scss,
   codeThemePath ? ./assets/default-syntax.theme,
@@ -64,6 +65,7 @@ in
        --toc \
        --standalone \
     ''
+    + optionalString embedResources ''--self-contained \''
     + optionalString sandboxing ''--sandbox \''
     + optionalString (templatePath != null) ''--template ${templatePath} \''
     + optionalString (styleSheetPath != null) ''--css ${ndg-stylesheet.override {inherit styleSheetPath;}} \''


### PR DESCRIPTION
- Formats the README (uwu)
- Adds new args to modify default pandoc behaviour