### PR TITLE
builder: enable adding anchor link to headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,15 +65,17 @@ self.nixosConfigurations.myHost
 
 <!-- deno-fmt-ignore-end -->
 
+[pandoc template]: https://pandoc.org/MANUAL.html#templates
+[pandoc syntax highlighting file]: https://pandoc.org/MANUAL.html#syntax-highlighting
+
+- `title`: the title of your documentation page
 - `sandboxing`: whether to pass `--sandbox` to Pandoc
 - `embedResources`: whether `--self-contained` should be passed to Pandoc in
   order to generate an entirely self-contained HTML document
-- `title`: the title of your documentation page
-- `templatePath`: path to a
-  [pandoc template](https://pandoc.org/MANUAL.html#templates)
+- `templatePath`: path to a [pandoc template]
 - `styleSheetPath`: path to a Sassy CSS (SCSS) file that will compile to CSS
-- `codeThemePath`: path to a
-  [pandoc syntax highlighting file](https://pandoc.org/MANUAL.html#syntax-highlighting)
-  (note that it must be JSON with a `.theme` extension)
+- `codeThemePath`: path to a [pandoc syntax highlighting file] (note that it
+  must be JSON with a `.theme` extension)
+- `generateLinkAnchors`: whether to generate anchors next to links
 - `optionsDocArgs`: additional arguments to pass to the `nixosOptionsDoc`
   package

--- a/pkgs/assets/default-styles.scss
+++ b/pkgs/assets/default-styles.scss
@@ -447,3 +447,36 @@ table {
     font-size: 20px;
   }
 }
+
+// Link icons for anchored headings
+$anchor-font-size: 80%;
+$anchor-hover-opacity: 1;
+$anchor-opacity: 0.5;
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  position: relative;
+
+  .anchor {
+    position: absolute;
+    top: 50%;
+    left: 2em; // HACK, 2em might not work on different font sizes or viewports...
+    transform: translateY(-50%);
+    margin-left: 0.5em;
+
+    &::before {
+      content: "🔗";
+      display: inline-block;
+      font-size: $anchor-font-size;
+      opacity: $anchor-opacity;
+    }
+
+    &:hover::before {
+      opacity: $anchor-hover-opacity;
+    }
+  }
+}

--- a/pkgs/assets/filters/anchor.lua
+++ b/pkgs/assets/filters/anchor.lua
@@ -1,0 +1,15 @@
+-- Adds anchor links to headings with IDs.
+-- Based on the header anchor links Lua filter from Pandoc's website
+-- https://github.com/jgm/pandoc-website/blob/160240324036ae620395836ff8092f724fb8f3f2/tools/anchor-links.lua
+function Header(h)
+    if h.identifier and h.identifier ~= '' then
+        local anchor_link = pandoc.Link(
+            '',                                            -- empty content
+            '#' .. h.identifier,                           -- href
+            '',                                            -- title
+            { class = 'anchor', ['aria-hidden'] = 'true' } -- attributes
+        )
+        h.content:insert(1, anchor_link)
+    end
+    return h
+end

--- a/pkgs/builder.nix
+++ b/pkgs/builder.nix
@@ -29,6 +29,7 @@
       modules = rawModules ++ [{_module.check = checkModules;}];
       inherit specialArgs;
     },
+  # Builder configuration
   title ? "My Option Documentation",
   templatePath ? ./assets/default-template.html,
   styleSheetPath ? ./assets/default-styles.scss,
@@ -36,6 +37,7 @@
   optionsDocArgs ? {},
   sandboxing ? true,
   embedResources ? false,
+  generateLinkAnchors ? true,
 } @ args:
 assert args ? specialArgs -> args ? rawModules;
 assert args ? evaluatedModules -> !(args ? rawModules); let
@@ -81,6 +83,7 @@ in
        --toc \
        --standalone \
     ''
+    + optionalString generateLinkAnchors ''--lua-filter=${./assets/filters/anchor.lua} \''
     + optionalString embedResources ''--self-contained \''
     + optionalString sandboxing ''--sandbox \''
     + optionalString (templatePath != null) ''--template ${templatePath} \''


### PR DESCRIPTION
Adds an option to generate anchor links next to option headers.