### PR TITLE
builder: more robust argument handling

### DIFF
--- a/pkgs/builder.nix
+++ b/pkgs/builder.nix
@@ -40,6 +40,7 @@
   sandboxing ? true,
   embedResources ? false,
   generateLinkAnchors ? true,
+  outPath ? "share/doc",
 } @ args:
 assert args ? specialArgs -> args ? rawModules;
 assert args ? evaluatedModules -> !(args ? rawModules); let
@@ -62,11 +63,12 @@ assert args ? evaluatedModules -> !(args ? rawModules); let
 
   pandocArgs = {
     luaFilters = filters ++ optionals generateLinkAnchors [./assets/filters/anchor.lua];
+    finalOutPath = "$out" + /${toString outPath}; # toString handles 'null' case
   };
 in
   runCommandLocal "generate-option-docs.html" {nativeBuildInputs = [pandoc];} (
     ''
-      mkdir -p $out/share/doc
+      mkdir -p ${pandocArgs.finalOutPath}
 
       ${optionalString genJsonDocs ''
         cp -vf ${configJSON}/share/doc/nixos/options.json $out/share/doc/options.json
@@ -96,5 +98,5 @@ in
     + optionalString (templatePath != null) ''--template ${templatePath} \''
     + optionalString (styleSheetPath != null) ''--css ${ndg-stylesheet.override {inherit styleSheetPath;}} \''
     + optionalString (codeThemePath != null) ''--highlight-style ${codeThemePath} \''
-    + "-o $out/share/doc/index.html"
+    + "-o ${pandocArgs.finalOutPath}/index.html"
   )

--- a/pkgs/builder.nix
+++ b/pkgs/builder.nix
@@ -63,7 +63,7 @@ assert args ? evaluatedModules -> !(args ? rawModules); let
 
   pandocArgs = {
     luaFilters = filters ++ optionals generateLinkAnchors [./assets/filters/anchor.lua];
-    finalOutPath = "$out" + /${toString outPath}; # toString handles 'null' case
+    finalOutPath = "$out/${toString outPath}"; # toString handles 'null' case
   };
 in
   runCommandLocal "generate-option-docs.html" {nativeBuildInputs = [pandoc];} (

--- a/pkgs/builder.nix
+++ b/pkgs/builder.nix
@@ -41,62 +41,69 @@
   embedResources ? false,
   generateLinkAnchors ? true,
   outPath ? "share/doc",
-} @ args:
-assert args ? specialArgs -> args ? rawModules;
-assert args ? evaluatedModules -> !(args ? rawModules); let
-  inherit (lib.strings) optionalString concatStringsSep;
-  inherit (lib.lists) optionals;
-
-  configMD =
-    (nixosOptionsDoc (
-      (removeAttrs optionsDocArgs ["options"])
-      // {inherit (evaluatedModules) options;}
-    ))
-    .optionsCommonMark;
-
-  configJSON =
-    (nixosOptionsDoc (
-      (removeAttrs optionsDocArgs ["options"])
-      // {inherit (evaluatedModules) options;}
-    ))
-    .optionsJSON;
-
-  pandocArgs = {
-    luaFilters = filters ++ optionals generateLinkAnchors [./assets/filters/anchor.lua];
-    finalOutPath = "$out/${toString outPath}"; # toString handles 'null' case
-  };
+} @ args: let
+  inherit (builtins) isString;
+  inherit (lib.asserts) assertMsg;
 in
-  runCommandLocal "generate-option-docs.html" {nativeBuildInputs = [pandoc];} (
-    ''
-      mkdir -p ${pandocArgs.finalOutPath}
+  # TODO explain this one
+  assert args ? specialArgs -> args ? rawModules;
+  assert assertMsg (args ? evaluatedModules -> !(args ? rawModules)) "evaluatedModules and rawModules are mutually exclusive";
+  assert assertMsg (isString outPath) "outPath must be a string";
+  # TODO assert that outPath doesn't escape $out
+    let
+      inherit (lib.strings) optionalString concatStringsSep;
+      inherit (lib.lists) optionals;
 
-      ${optionalString genJsonDocs ''
-        cp -vf ${configJSON}/share/doc/nixos/options.json $out/share/doc/options.json
-      ''}
+      configMD =
+        (nixosOptionsDoc (
+          (removeAttrs optionsDocArgs ["options"])
+          // {inherit (evaluatedModules) options;}
+        ))
+        .optionsCommonMark;
 
-      # Convert to Pandoc markdown instead of using commonmark directly
-      # as the former automatically generates heading IDs and TOC links.
-      ${pandocCmd} \
-        --from commonmark \
-        --to markdown \
-        ${configMD} |
+      configJSON =
+        (nixosOptionsDoc (
+          (removeAttrs optionsDocArgs ["options"])
+          // {inherit (evaluatedModules) options;}
+        ))
+        .optionsJSON;
+
+      pandocArgs = {
+        luaFilters = filters ++ optionals generateLinkAnchors [./assets/filters/anchor.lua];
+        finalOutPath = "$out/${outPath}";
+      };
+    in
+      runCommandLocal "generate-option-docs.html" {nativeBuildInputs = [pandoc];} (
+        ''
+          mkdir -p ${pandocArgs.finalOutPath}
+
+          ${optionalString genJsonDocs ''
+            cp -vf ${configJSON}/share/doc/nixos/options.json $out/share/doc/options.json
+          ''}
+
+          # Convert to Pandoc markdown instead of using commonmark directly
+          # as the former automatically generates heading IDs and TOC links.
+          ${pandocCmd} \
+            --from commonmark \
+            --to markdown \
+            ${configMD} |
 
 
-      # Convert Pandoc markdown to HTML using our own template and css files
-      # where available. --sandbox is passed for extra security by default
-      # with an optional override to disable it.
-      ${pandocCmd} \
-       --from markdown \
-       --to html \
-       --metadata title="${title}" \
-       --toc \
-       --standalone \
-    ''
-    + optionalString (pandocArgs.luaFilters != []) ''${concatStringsSep " " (map (f: "--lua-filter=" + f) pandocArgs.luaFilters)} \''
-    + optionalString embedResources ''--embed-resources --standalone \''
-    + optionalString sandboxing ''--sandbox \''
-    + optionalString (templatePath != null) ''--template ${templatePath} \''
-    + optionalString (styleSheetPath != null) ''--css ${ndg-stylesheet.override {inherit styleSheetPath;}} \''
-    + optionalString (codeThemePath != null) ''--highlight-style ${codeThemePath} \''
-    + "-o ${pandocArgs.finalOutPath}/index.html"
-  )
+          # Convert Pandoc markdown to HTML using our own template and css files
+          # where available. --sandbox is passed for extra security by default
+          # with an optional override to disable it.
+          ${pandocCmd} \
+           --from markdown \
+           --to html \
+           --metadata title="${title}" \
+           --toc \
+           --standalone \
+        ''
+        + optionalString (pandocArgs.luaFilters != []) ''${concatStringsSep " " (map (f: "--lua-filter=" + f) pandocArgs.luaFilters)} \''
+        + optionalString embedResources ''--embed-resources --standalone \''
+        + optionalString sandboxing ''--sandbox \''
+        + optionalString (templatePath != null) ''--template ${templatePath} \''
+        + optionalString (styleSheetPath != null) ''--css ${ndg-stylesheet.override {inherit styleSheetPath;}} \''
+        + optionalString (codeThemePath != null) ''--highlight-style ${codeThemePath} \''
+        + "-o ${pandocArgs.finalOutPath}/index.html"
+      )


### PR DESCRIPTION
Adds `filters` to builder arguments to allow for multiple Lua filters, which is a very powerful feature of Pandoc. Also adds an argument to specify the out path, so that users are not locked to a specific directory.

I initially wanted to build a wrapper for Pandoc that NDG could use, but our use case is niche enough that just handling more arguments is good enough.