### PR TITLE
ndg: fix styling mistakes; extend templating

### DIFF
--- a/ndg/README.md
+++ b/ndg/README.md
@@ -137,12 +137,15 @@ users always start with the latest default templates and can easily update them
 when ndg is upgraded. Though, ndg will fall back to internal templates when none
 are provided.
 
+See the [templating documntation](./docs/TEMPLATING.md) for details about the
+templating. If your use-case is not supported, feel free to request a feature!
+
 ## Detailed Usage
 
 The first subcommand in ndg's compartmentalized architecture is for HTML
 generation. The `html` subcommand includes the following options:
 
-```
+```plaintext
 Options:
   -i, --input-dir <INPUT_DIR>
           Path to the directory containing markdown files

--- a/ndg/docs/TEMPLATING.md
+++ b/ndg/docs/TEMPLATING.md
@@ -1,0 +1,358 @@
+# Templating Guide
+
+`ndg` supports a flexible templating system powered by
+[Tera](https://crates.io/crates/tera) and backed by our own templating logic.
+Using this system, you may customize the appearance and structure of your
+generated documentation while avoiding what could be referred to as a "vendor
+lock-in".
+
+## Template Types
+
+There are several "special" templates that is expected during documentation
+generation. ndg bundles its own templates that will be used by default, but you
+may override them as you wish to make your documentation site truly unique.
+
+### Core Templates
+
+- **`default.html`** - Main template for documentation pages
+- **`options.html`** - Template for NixOS module options page
+- **`search.html`** - Template for the search page
+- **`navbar.html`** - Navigation bar template (shared across all pages)
+- **`footer.html`** - Footer template (shared across all pages)
+- **`options_toc.html`** - Table of contents template for options page
+
+### Assets
+
+- **`default.css`** - Default stylesheet
+- **`main.js`** - Scripts loaded for interactivity
+- **`search.js`** - Secondary script used for the search functionality
+
+## Using Custom Templates
+
+As mentioned before, you may
+
+### Template Directory
+
+Using the template directory is the recommended way of overriding default
+templates of ndg. In this method, you must use a template directory containing
+all your custom templates:
+
+```bash
+ndg html --template-dir ./my-templates
+```
+
+Or in your `ndg.toml`:
+
+```toml
+template_dir = "./my-templates"
+```
+
+> [!TIP]
+> The `ndg export-templates` command can be used to create a directory with the
+> default templates, meant to be overridden by the user. ndg will prioritize
+> templates provided by the user wherever provided. Missing page templates will
+> cause ndg to use the default template for that page variant. E.g., providing a
+> template directory with just `default.html` would use the `default.html`
+> provided by the user, but the built-in templates for rest of the templatable
+> components.
+
+### Individual Template File
+
+A dirty legacy method of quickly overriding `default.html` exists as
+`--template`. This allows providing a quick override for **only the default
+template**, which may be useful if you only want to override styles for
+arbitrary generated pages, and not special pages or components such as the
+navbar.
+
+```bash
+ndg html --template ./my-custom-template.html
+```
+
+This will use `my-custom-template.html` as the default.html template.
+
+## Per-File Templates
+
+You can create file-specific templates that will be used instead of
+`default.html` for matching markdown files.
+
+**Example:**
+
+- `foo.md` -> will use `foo.html` template if it exists, otherwise falls back to
+  `default.html`
+- `about.md` -> will use `about.html` template if it exists, otherwise falls
+  back to `default.html`
+
+This is useful when you want different layouts for different sections of your
+documentation. It can also be used for, e.g., `404.html` to generate your own
+404 page with Markdown.
+
+## Template Components
+
+### Navbar Template (`navbar.html`)
+
+Customize the navigation bar that appears in the header of all pages.
+
+**Available Variables:**
+
+- `{{ has_options }}` - HTML attributes for options link styling (e.g.,
+  `class="active"`)
+- `{{ generate_search }}` - Boolean indicating if search is enabled
+- `{{ options_path }}` - Relative path to options page
+- `{{ search_path }}` - Relative path to search page
+
+#### Example
+
+```html
+<nav class="header-nav">
+  <ul>
+    <li {{ has_options|safe }}>
+      <a href="{{ options_path }}">Options</a>
+    </li>
+    {% if generate_search %}
+    <li><a href="{{ search_path }}">Search</a></li>
+    {% endif %}
+    <li><a href="/about.html">About</a></li>
+  </ul>
+</nav>
+```
+
+### Footer Template (`footer.html`)
+
+Customize the footer that appears at the bottom of all pages.
+
+**Available Variables:**
+
+- `{{ footer_text }}` - Footer text from configuration
+
+#### Example
+
+```html
+<footer>
+  <p>{{ footer_text }}</p>
+  <p>Built with <a href="https://github.com/notashelf/ndg">ndg</a></p>
+</footer>
+```
+
+## Exporting Default Templates
+
+To export all default templates for customization:
+
+```bash
+ndg export-templates --output ./templates
+```
+
+This will create a directory with all default templates that you can then
+modify.
+
+Use `--force` to overwrite existing files:
+
+```bash
+ndg export-templates --output ./templates --force
+```
+
+## Template Variables
+
+### Common Variables (Available in all templates)
+
+- `{{ title }}` - Page title
+- `{{ site_title }}` - Site title from configuration
+- `{{ footer_text }}` - Footer text from configuration
+- `{{ content|safe }}` - Rendered markdown content
+- `{{ toc|safe }}` - Table of contents HTML
+- `{{ doc_nav|safe }}` - Document navigation HTML
+- `{{ navbar_html|safe }}` - Rendered navbar HTML
+- `{{ footer_html|safe }}` - Rendered footer HTML
+- `{{ has_options }}` - Options link styling attributes
+- `{{ generate_search }}` - Boolean for search feature
+- `{{ custom_scripts|safe }}` - Custom scripts HTML
+- `{{ meta_tags_html|safe }}` - Meta tags HTML
+- `{{ opengraph_html|safe }}` - OpenGraph tags HTML
+
+### Asset Paths
+
+- `{{ stylesheet_path }}` - Path to stylesheet
+- `{{ main_js_path }}` - Path to main JavaScript file
+- `{{ search_js_path }}` - Path to search JavaScript file
+- `{{ index_path }}` - Path to index page
+- `{{ options_path }}` - Path to options page
+- `{{ search_path }}` - Path to search page
+
+### Options Page Specific
+
+- `{{ heading }}` - Page heading
+- `{{ options|safe }}` - Rendered options HTML
+
+## Template Syntax
+
+Templates use the [Tera](https://keats.github.io/tera/) templating engine, which
+is similar to Jinja2/Django templates. Below are some examples provided for your
+convenience. Please refer to the
+[Tera's documentation](https://keats.github.io/tera/docs/#templates) for more
+details. Everything supported by Tera is supported in ndg.
+
+### Variables
+
+```html
+{{ variable_name }}
+```
+
+Use the `safe` filter to render HTML without escaping:
+
+```html
+{{ html_content|safe }}
+```
+
+### Conditionals
+
+```html
+{% if generate_search %}
+<div class="search">...</div>
+{% endif %}
+```
+
+### Loops
+
+```html
+{% for item in items %}
+<li>{{ item }}</li>
+{% endfor %}
+```
+
+## Example: Custom Theme
+
+Here's an example of creating a custom theme:
+
+1. Export the default templates:
+
+   ```bash
+   ndg export-templates --output ./my-theme
+   ```
+
+2. Customize the templates in `./my-theme/`
+
+3. Modify `navbar.html` to add custom links:
+
+   ```html
+   <nav class="header-nav">
+     <ul>
+       <li><a href="/docs.html">Docs</a></li>
+       <li {{ has_options|safe }}>
+         <a href="{{ options_path }}">Options</a>
+       </li>
+       <li><a href="/blog.html">Blog</a></li>
+       {% if generate_search %}
+       <li><a href="{{ search_path }}">Search</a></li>
+       {% endif %}
+     </ul>
+   </nav>
+   ```
+
+4. Update `footer.html`:
+
+   ```html
+   <footer>
+     <div class="footer-content">
+       <p>{{ footer_text }}</p>
+       <p>
+         © 2025 My Project | <a href="/privacy.html">Privacy</a> | <a
+         >href="/terms.html">Terms</a>
+       </p>
+     </div>
+   </footer>
+   ```
+
+5. Create a custom template for your homepage (`index.html`):
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>{{ title }}</title>
+    <link rel="stylesheet" href="{{ stylesheet_path }}" />
+  </head>
+  <body>
+    <header>
+      <h1 class="site-title">
+        <a href="{{ index_path }}">{{ site_title }}</a>
+      </h1>
+      {{ navbar_html|safe }}
+    </header>
+
+    <main class="hero">
+      <h1>Welcome to My Documentation</h1>
+      {{ content|safe }}
+    </main>
+
+    {{ footer_html|safe }}
+  </body>
+</html>
+```
+
+Now you may use the custom theme freely using the `--template-dir` option.
+
+```bash
+ndg option --template-dir ./my-theme
+```
+
+## Configuration Example
+
+In `ndg.toml`:
+
+```toml
+title = "My Awesome Site"
+footer_text = "Built with ☕ and ♥️ "
+template_dir = "./templates"
+stylesheet_paths = ["./assets/custom.css"]
+script_paths = ["./assets/custom.js"]
+
+[opengraph]
+"og:title" = "My Documentation"
+"og:description" = "Comprehensive documentation for my project"
+"og:image" = "./assets/banner.png"
+
+[meta_tags]
+description = "My amazing documentation"
+keywords = "docs, markdown, documentation"
+```
+
+## Best Practices
+
+For a clean(er) experience, we recommend that you:
+
+1. **Start with defaults**: Export the default templates and modify them rather
+   than starting from scratch
+2. **Keep it modular**: Use the navbar and footer templates to keep common
+   elements consistent
+3. **Preserve CSS classes**: Keep the default CSS classes to maintain
+   functionality (sidebar toggle, search, etc.)
+
+The nature of a mixed-approach that ndg supports may sometimes yield results
+that can be best described as annoying. Though it is perfectly possible to have
+a good design _and_ keep your sanity.
+
+## Troubleshooting
+
+### Template not found
+
+Make sure your template directory contains the required templates or that
+fallback templates are available.
+
+### Variables not rendering
+
+- Check variable names match the documentation
+- Use `{{ variable|safe }}` for HTML content
+- Check for typos in variable names
+
+### Styling issues
+
+- Ensure your custom CSS doesn't conflict with default styles
+- Check that CSS classes used by JavaScript features are preserved
+- Test responsive design on mobile devices
+
+### Per-file template not working
+
+- Ensure the template filename matches the markdown filename (e.g., `foo.html`
+  for `foo.md`)
+- Check that the template is in the configured template directory
+- Verify the template has valid Tera syntax

--- a/ndg/src/config/mod.rs
+++ b/ndg/src/config/mod.rs
@@ -605,6 +605,10 @@ impl Config {
       "options_toc.html",
       include_str!("../../templates/options_toc.html"),
     );
+    templates
+      .insert("navbar.html", include_str!("../../templates/navbar.html"));
+    templates
+      .insert("footer.html", include_str!("../../templates/footer.html"));
 
     // CSS and JS assets
     templates

--- a/ndg/templates/default.css
+++ b/ndg/templates/default.css
@@ -286,7 +286,8 @@ body .mobile-sidebar-fab {
 .container {
   display: flex;
   flex-direction: column;
-  width: 100wh;
+  min-height: 100vh;
+  width: 100%;
   max-width: 100%;
   margin: 0 auto;
 }
@@ -404,10 +405,11 @@ header {
 
 /* Sidebar  */
 .sidebar {
-  position: sticky;
+  position: fixed;
+  left: 0;
   top: var(--header-height);
   width: 300px;
-  height: calc(100vh - 64px);
+  height: calc(100vh - var(--header-height));
   background-color: var(--sidebar-bg);
   padding: var(--space-4);
   border-right: 1px solid var(--border-color);
@@ -458,7 +460,6 @@ header {
   .sidebar-collapsed &,
   .sidebar-collapsed-init & {
     transform: translateX(-100%);
-    width: 0px;
   }
 }
 
@@ -1360,8 +1361,6 @@ h6:hover .copy-link {
 /* Responsive Design */
 @media (max-width: 800px) {
   .sidebar {
-    position: fixed;
-    left: 0;
     top: 60px;
     height: calc(100vh - 60px);
     z-index: 90;

--- a/ndg/templates/default.html
+++ b/ndg/templates/default.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
@@ -27,16 +27,7 @@
             <a href="{{ index_path }}">{{ site_title }}</a>
           </h1>
 
-          <nav class="header-nav">
-            <ul>
-              <li {{ has_options|safe }}>
-                <a href="{{ options_path }}">Options</a>
-              </li>
-              {% if generate_search %}
-              <li><a href="{{ search_path }}">Search</a></li>
-              {% endif %}
-            </ul>
-          </nav>
+          {{ navbar_html|safe }}
         </div>
         {% if generate_search %}
         <div class="search-container">
@@ -76,9 +67,7 @@
         <main class="content">{{ content|safe }}</main>
       </div>
 
-      <footer>
-        <p>{{ footer_text }}</p>
-      </footer>
+      {{ footer_html|safe }}
     </div>
 
     {{ custom_scripts|safe }}

--- a/ndg/templates/footer.html
+++ b/ndg/templates/footer.html
@@ -1,0 +1,3 @@
+<footer>
+  <p>{{ footer_text }}</p>
+</footer>

--- a/ndg/templates/navbar.html
+++ b/ndg/templates/navbar.html
@@ -1,0 +1,10 @@
+<nav class="header-nav">
+  <ul>
+    <li {{ has_options|safe }}>
+      <a href="{{ options_path }}">Options</a>
+    </li>
+    {% if generate_search %}
+    <li><a href="{{ search_path }}">Search</a></li>
+    {% endif %}
+  </ul>
+</nav>

--- a/ndg/templates/options.html
+++ b/ndg/templates/options.html
@@ -27,17 +27,7 @@
             <a href="{{ index_path }}">{{ site_title }}</a>
           </h1>
         </div>
-        <nav class="header-nav">
-          <ul>
-            <li {{ has_options|safe }}>
-              <a href="{{ options_path }}">Options</a>
-            </li>
-            {% if generate_search %}
-            <li><a href="{{ search_path }}">Search</a></li>
-            {% endif %}
-          </ul>
-        </nav>
-        {% if generate_search %}
+        {{ navbar_html|safe }} {% if generate_search %}
         <div class="search-container">
           <input type="text" id="search-input" placeholder="Search..." />
           <div id="search-results" class="search-results"></div>
@@ -91,9 +81,7 @@
         </main>
       </div>
 
-      <footer>
-        <p>{{ footer_text }}</p>
-      </footer>
+      {{ footer_html|safe }}
     </div>
 
     {{ custom_scripts|safe }}

--- a/ndg/templates/search.html
+++ b/ndg/templates/search.html
@@ -25,14 +25,7 @@
             <a href="{{ index_path }}">{{ site_title }}</a>
           </h1>
         </div>
-        <nav class="header-nav">
-          <ul>
-            <li {{ has_options|safe }}>
-              <a href="{{ options_path }}">Options</a>
-            </li>
-            <li class="active"><a href="{{ search_path }}">Search</a></li>
-          </ul>
-        </nav>
+        {{ navbar_html|safe }}
         <div class="search-container">
           <input type="text" id="search-input" placeholder="Search..." />
           <div id="search-results" class="search-results"></div>
@@ -85,9 +78,7 @@
         </main>
       </div>
 
-      <footer>
-        <p>{{ footer_text }}</p>
-      </footer>
+      {{ footer_html|safe }}
     </div>
 
     {{ custom_scripts|safe }}


### PR DESCRIPTION
Fixes a few CSS issues that come from the inherent shittiness of CSS (not at all my fault wdym) and extends the templating option to support footer templates, header templatees and per-file templating.

Also used this opportunity to extend the templating documentation, and refactor it to its own page. Maybe I'll render documentation for ndg using ndg...

Signed-off-by: NotAShelf <raf@notashelf.dev>
Change-Id: I6a6a6964977044a301ef9d7865bda7aae65ed17b