### PR TITLE
ndg-commonmark: test MySt-like autolinks

### DIFF
--- a/ndg-commonmark/src/lib.rs
+++ b/ndg-commonmark/src/lib.rs
@@ -58,6 +58,7 @@ pub use crate::processor::{
   process_block_elements,
   process_file_includes,
   process_inline_anchors,
+  process_myst_autolinks,
   process_option_references,
   process_role_markup,
 };

--- a/ndg-commonmark/src/processor/mod.rs
+++ b/ndg-commonmark/src/processor/mod.rs
@@ -26,6 +26,7 @@ pub use core::{ProcessorFeature, collect_markdown_files, extract_inline_text};
 pub use extensions::apply_gfm_extensions;
 #[cfg(feature = "nixpkgs")]
 pub use extensions::process_manpage_references;
+pub use extensions::process_myst_autolinks;
 #[cfg(feature = "ndg-flavored")]
 pub use extensions::process_option_references;
 #[cfg(any(feature = "nixpkgs", feature = "ndg-flavored"))]
@@ -67,6 +68,7 @@ mod tests {
         "option",
         "hjem.users.<name>.enable",
         None,
+        true,
       );
 
       // Should escape < and > characters in content
@@ -97,17 +99,17 @@ mod tests {
       let content = "<script>alert('xss')</script>";
 
       let command_result =
-        super::extensions::format_role_markup("command", content, None);
+        super::extensions::format_role_markup("command", content, None, true);
       assert!(command_result.contains("&lt;script&gt;"));
       assert!(!command_result.contains("<script>alert"));
 
       let env_result =
-        super::extensions::format_role_markup("env", content, None);
+        super::extensions::format_role_markup("env", content, None, true);
       assert!(env_result.contains("&lt;script&gt;"));
       assert!(!env_result.contains("<script>alert"));
 
       let file_result =
-        super::extensions::format_role_markup("file", content, None);
+        super::extensions::format_role_markup("file", content, None, true);
       assert!(file_result.contains("&lt;script&gt;"));
       assert!(!file_result.contains("<script>alert"));
     }
@@ -122,6 +124,7 @@ mod tests {
         "option",
         "hjem.users.<name>.enable",
         None,
+        true,
       );
 
       // Should not produce broken HTML like:
@@ -148,6 +151,7 @@ mod tests {
         "option",
         "services.foo.<bar>.enable",
         None,
+        true,
       );
 
       // Option ID should preserve angle brackets

--- a/ndg-commonmark/src/processor/process.rs
+++ b/ndg-commonmark/src/processor/process.rs
@@ -148,6 +148,7 @@ pub fn create_processor(preset: ProcessorPreset) -> MarkdownProcessor {
         highlight_code:    true,
         highlight_theme:   None,
         manpage_urls_path: None,
+        auto_link_options: true,
       }
     },
     ProcessorPreset::Ndg => {
@@ -157,6 +158,7 @@ pub fn create_processor(preset: ProcessorPreset) -> MarkdownProcessor {
         highlight_code:    true,
         highlight_theme:   Some("github".to_string()),
         manpage_urls_path: None,
+        auto_link_options: true,
       }
     },
     ProcessorPreset::Nixpkgs => {
@@ -166,6 +168,7 @@ pub fn create_processor(preset: ProcessorPreset) -> MarkdownProcessor {
         highlight_code:    true,
         highlight_theme:   Some("github".to_string()),
         manpage_urls_path: None,
+        auto_link_options: true,
       }
     },
   };

--- a/ndg-commonmark/src/processor/types.rs
+++ b/ndg-commonmark/src/processor/types.rs
@@ -41,6 +41,11 @@ pub struct MarkdownOptions {
 
   /// Optional: Path to manpage URL mappings (for {manpage} roles).
   pub manpage_urls_path: Option<String>,
+
+  /// Enable automatic linking for option role markup.
+  /// When `true`, `{option}` roles will be converted to links to options.html.
+  /// When `false`, they will be rendered as plain `<code>` elements.
+  pub auto_link_options: bool,
 }
 
 impl MarkdownOptions {
@@ -53,6 +58,7 @@ impl MarkdownOptions {
       highlight_code:    cfg!(any(feature = "syntastica", feature = "syntect")),
       highlight_theme:   None,
       manpage_urls_path: None,
+      auto_link_options: true,
     }
   }
 
@@ -69,6 +75,7 @@ impl MarkdownOptions {
       highlight_code,
       highlight_theme: None,
       manpage_urls_path: None,
+      auto_link_options: true,
     }
   }
 }
@@ -81,6 +88,7 @@ impl Default for MarkdownOptions {
       highlight_code:    cfg!(feature = "syntastica"),
       manpage_urls_path: None,
       highlight_theme:   None,
+      auto_link_options: true,
     }
   }
 }
@@ -198,6 +206,13 @@ impl MarkdownOptionsBuilder {
   #[must_use]
   pub fn manpage_urls_path<S: Into<String>>(mut self, path: Option<S>) -> Self {
     self.options.manpage_urls_path = path.map(Into::into);
+    self
+  }
+
+  /// Enable or disable automatic linking for {option} role markup.
+  #[must_use]
+  pub const fn auto_link_options(mut self, enabled: bool) -> Self {
+    self.options.auto_link_options = enabled;
     self
   }
 

--- a/ndg-commonmark/src/syntax/syntastica.rs
+++ b/ndg-commonmark/src/syntax/syntastica.rs
@@ -237,7 +237,9 @@ impl SyntaxHighlighter for SyntasticaHighlighter {
 /// excellent language support including native Nix highlighting.
 pub fn create_syntastica_manager() -> SyntaxResult<SyntaxManager> {
   let highlighter = Box::new(SyntasticaHighlighter::new()?);
-  let mut config = SyntaxConfig::default();
-  config.default_theme = Some("one-dark".to_string());
+  let config = SyntaxConfig {
+    default_theme: Some("one-dark".to_string()),
+    ..Default::default()
+  };
   Ok(SyntaxManager::new(highlighter, config))
 }

--- a/ndg-commonmark/tests/integration.rs
+++ b/ndg-commonmark/tests/integration.rs
@@ -4,7 +4,7 @@ use ndg_commonmark::{MarkdownOptions, MarkdownProcessor};
 /// Mainly I just want to make sure this went as smoothly as it could, and that
 /// the new parser is as robust as I expect.
 #[test]
-fn test_complete_migration_integration() {
+fn test_migration_integration() {
   let processor = MarkdownProcessor::new(MarkdownOptions::default());
 
   let complex_markdown = r#"# Main Documentation
@@ -179,9 +179,12 @@ Visit the [](#getting-started) guide.
   // Verify empty link humanization
   assert!(result.html.contains("<a href=\"#intro\">introduction</a>"));
 
-  // NOTE: empty link without text currently not processed correctly
-  // this is a known issue
-  assert!(result.html.contains("](#getting-started)"));
+  // Verify empty anchor links are processed correctly
+  assert!(
+    result
+      .html
+      .contains("<a href=\"#getting-started\">Getting Started</a>")
+  );
 
   // Verify no malformed HTML
   assert!(!result.html.contains("href=\"<a href"));

--- a/ndg-commonmark/tests/markup.rs
+++ b/ndg-commonmark/tests/markup.rs
@@ -200,7 +200,7 @@ fn test_option_reference() {
 #[test]
 fn test_myst_role_markup() {
   let md = r"{command}`foo`";
-  let html = ndg_commonmark::process_role_markup(md, None);
+  let html = ndg_commonmark::process_role_markup(md, None, true);
   assert_html_contains(&html, &[r#"<code class="command">foo</code>"#]);
 }
 
@@ -224,7 +224,8 @@ fn test_manpage_role_with_url() {
   opts.manpage_urls_path = Some(json_path.to_str().unwrap().to_string());
   let processor = ndg_commonmark::MarkdownProcessor::new(opts);
 
-  let html = ndg_commonmark::process_role_markup(md, processor.manpage_urls());
+  let html =
+    ndg_commonmark::process_role_markup(md, processor.manpage_urls(), true);
   assert_html_contains(&html, &[
     r#"<a href="https://www.gnu.org/software/coreutils/manual/html_node/cat-invocation.html" class="manpage-reference">cat(1)</a>"#,
   ]);
@@ -250,7 +251,8 @@ fn test_manpage_role_without_url() {
   opts.manpage_urls_path = Some(json_path.to_str().unwrap().to_string());
   let processor = ndg_commonmark::MarkdownProcessor::new(opts);
 
-  let html = ndg_commonmark::process_role_markup(md, processor.manpage_urls());
+  let html =
+    ndg_commonmark::process_role_markup(md, processor.manpage_urls(), true);
   assert_html_contains(&html, &[
     r#"<span class="manpage-reference">doesnotexist(1)</span>"#,
   ]);
@@ -264,7 +266,7 @@ fn test_role_markup_in_lists() {
 - {option}`services.nginx.enable`
 - {var}`pkgs`
 - {manpage}`nix.conf(5)`";
-  let html = ndg_commonmark::process_role_markup(md, None);
+  let html = ndg_commonmark::process_role_markup(md, None, true);
 
   // Test that all role types are processed correctly
   assert_html_contains(&html, &[
@@ -295,21 +297,21 @@ fn test_role_markup_in_lists() {
 fn test_role_markup_edge_cases() {
   // Test role with special characters
   let md = r"{file}`/path/with-dashes_and.dots`";
-  let html = ndg_commonmark::process_role_markup(md, None);
+  let html = ndg_commonmark::process_role_markup(md, None, true);
   assert_html_contains(&html, &[
     r#"<code class="file-path">/path/with-dashes_and.dots</code>"#,
   ]);
 
   // Test role with spaces
   let md = r"{command}`ls -la | grep test`";
-  let html = ndg_commonmark::process_role_markup(md, None);
+  let html = ndg_commonmark::process_role_markup(md, None, true);
   assert_html_contains(&html, &[
     r#"<code class="command">ls -la | grep test</code>"#,
   ]);
 
   // Test unknown role type
   let md = r"{unknown}`content`";
-  let html = ndg_commonmark::process_role_markup(md, None);
+  let html = ndg_commonmark::process_role_markup(md, None, true);
   assert_html_contains(&html, &[
     r#"<span class="unknown-markup">content</span>"#,
   ]);
@@ -368,6 +370,154 @@ fn test_myst_autolink_bracket() {
   assert_html_contains(&html, &[
     r#"<a href="https://google.com">https://google.com</a>"#,
   ]);
+}
+
+#[test]
+fn test_auto_link_options_enabled() {
+  // Test that {option} roles are converted to links when auto_link_options is
+  // true
+  let md = r"Use {option}`services.nginx.enable` to configure nginx.";
+  let mut opts = ndg_commonmark::MarkdownOptions::default();
+  opts.auto_link_options = true;
+  let processor = ndg_commonmark::MarkdownProcessor::new(opts);
+  let html = processor.render(md).html;
+
+  assert_html_contains(&html, &[
+    r#"<a class="option-reference" href="options.html#option-services-nginx-enable"><code>services.nginx.enable</code></a>"#,
+  ]);
+}
+
+#[test]
+fn test_auto_link_options_disabled() {
+  // Test that {option} roles are NOT converted to links when auto_link_options
+  // is false
+  let md = r"Use {option}`services.nginx.enable` to configure nginx.";
+  let mut opts = ndg_commonmark::MarkdownOptions::default();
+  opts.auto_link_options = false;
+  let processor = ndg_commonmark::MarkdownProcessor::new(opts);
+  let html = processor.render(md).html;
+
+  // Should render as plain code, not as a link
+  assert!(
+    html.contains(r"<code>services.nginx.enable</code>"),
+    "Expected plain code element when auto_link_options is false. Got:\n{html}"
+  );
+  assert!(
+    !html.contains(r#"<a class="option-reference""#),
+    "Should not contain option-reference link when auto_link_options is \
+     false. Got:\n{html}"
+  );
+}
+
+#[test]
+fn test_option_anchor_link_empty() {
+  // Test [](#opt-services-nginx-enable) -> link to options.html with filled
+  // text
+  let md = r"See [](#opt-services-nginx-enable) for details.";
+  let html = ndg_html(md);
+
+  assert_html_contains(&html, &[
+    r#"<a href="options.html#opt-services-nginx-enable">services.nginx.enable</a>"#,
+  ]);
+}
+
+#[test]
+fn test_option_anchor_link_with_text() {
+  // Test [custom text](#opt-services-nginx-enable) -> link with custom text
+  let md = r"See [the nginx option](#opt-services-nginx-enable) for details.";
+  let html = ndg_html(md);
+
+  assert_html_contains(&html, &[
+    r#"<a href="options.html#opt-services-nginx-enable">the nginx option</a>"#,
+  ]);
+}
+
+#[test]
+fn test_option_anchor_link_complex() {
+  // Test multiple option anchor links
+  let md = r"Configure [](#opt-services-nginx-enable) and [](#opt-services-nginx-virtualHosts).";
+  let html = ndg_html(md);
+
+  assert_html_contains(&html, &[
+    r#"<a href="options.html#opt-services-nginx-enable">services.nginx.enable</a>"#,
+    r#"<a href="options.html#opt-services-nginx-virtualHosts">services.nginx.virtualHosts</a>"#,
+  ]);
+}
+
+#[test]
+fn test_option_anchor_link_not_opt_prefix() {
+  // Test that non-opt anchors are not transformed
+  let md = r"See [](#getting-started) for details.";
+  let html = ndg_html(md);
+
+  // Should NOT be transformed to options.html
+  assert!(
+    !html.contains("options.html"),
+    "Non-opt anchors should not be transformed. Got:\n{html}"
+  );
+  assert_html_contains(&html, &[
+    r##"<a href="#getting-started">Getting Started</a>"##,
+  ]);
+}
+
+#[test]
+fn test_auto_link_options_and_opt_anchors_regression() {
+  // Regression test for:
+  // 1. Configurable auto_link_options for {option} role markup
+  // 2. Support for [](#opt-*) syntax to link to options.html
+
+  // Test 1: auto_link_options enabled (default)
+  let md_with_role = r"Use {option}`services.nginx.enable` to enable nginx.";
+  let mut opts = ndg_commonmark::MarkdownOptions::default();
+  opts.auto_link_options = true;
+  let processor = ndg_commonmark::MarkdownProcessor::new(opts);
+  let html = processor.render(md_with_role).html;
+  assert!(
+    html.contains(r#"<a class="option-reference""#),
+    "Expected {{option}} role to be converted to link when auto_link_options \
+     is true. Got:\n{html}"
+  );
+
+  // Test 2: auto_link_options disabled
+  let mut opts = ndg_commonmark::MarkdownOptions::default();
+  opts.auto_link_options = false;
+  let processor = ndg_commonmark::MarkdownProcessor::new(opts);
+  let html = processor.render(md_with_role).html;
+  assert!(
+    !html.contains(r#"<a class="option-reference""#)
+      && html.contains(r"<code>services.nginx.enable</code>"),
+    "Expected {{option}} role to be plain code when auto_link_options is \
+     false. Got:\n{html}"
+  );
+
+  // Test 3: [](#opt-*) syntax with empty link text
+  let md_with_opt = r"See [](#opt-services-nginx-enable) for details.";
+  let processor = ndg_commonmark::MarkdownProcessor::new(
+    ndg_commonmark::MarkdownOptions::default(),
+  );
+  let html = processor.render(md_with_opt).html;
+  assert!(
+    html.contains(
+      r#"<a href="options.html#opt-services-nginx-enable">services.nginx.enable</a>"#
+    ),
+    "Expected [](#opt-*) to be converted to options.html link with option \
+     name. Got:\n{html}"
+  );
+
+  // Test 4: [](#opt-*) syntax with custom text
+  let md_with_custom_text =
+    r"See [the nginx option](#opt-services-nginx-enable) for details.";
+  let processor = ndg_commonmark::MarkdownProcessor::new(
+    ndg_commonmark::MarkdownOptions::default(),
+  );
+  let html = processor.render(md_with_custom_text).html;
+  assert!(
+    html.contains(
+      r#"<a href="options.html#opt-services-nginx-enable">the nginx option</a>"#
+    ),
+    "Expected [](#opt-*) with custom text to preserve custom text. \
+     Got:\n{html}"
+  );
 }
 
 #[test]

--- a/ndg-commonmark/tests/markup.rs
+++ b/ndg-commonmark/tests/markup.rs
@@ -361,6 +361,16 @@ fn test_autolink() {
 }
 
 #[test]
+fn test_myst_autolink_bracket() {
+  // MyST-style autolink: [](https://google.com)
+  let md = "Try [](https://google.com) for search.";
+  let html = ndg_html(md);
+  assert_html_contains(&html, &[
+    r#"<a href="https://google.com">https://google.com</a>"#,
+  ]);
+}
+
+#[test]
 fn test_header_extraction() {
   let md = "# Title\n\n## Section {#sec}\n### Subsection";
   let (_html, headers, title) = ndg_full_result(md);

--- a/ndg-commonmark/tests/processor.rs
+++ b/ndg-commonmark/tests/processor.rs
@@ -331,7 +331,10 @@ Empty links: <a href=\"#sec-introduction\"></a> and <a \
 
   // Should humanize anchor text by removing prefixes and formatting
   assert!(html.contains("<a href=\"#sec-introduction\">Introduction</a>"));
+  // opt- anchors should be converted to options.html links with proper option
+  // names
   assert!(html.contains(
-    "<a href=\"#opt-services-nginx-enable\">Services Nginx Enable</a>"
+    "<a href=\"options.html#opt-services-nginx-enable\">services.nginx.\
+     enable</a>"
   ));
 }

--- a/ndg/src/config/mod.rs
+++ b/ndg/src/config/mod.rs
@@ -527,8 +527,7 @@ impl Config {
     if !errors.is_empty() {
       let error_message = errors.join("\n");
       return Err(anyhow::anyhow!(
-        "Configuration path validation errors:\n{}",
-        error_message
+        "Configuration path validation errors:\n{error_message}"
       ));
     }
 
@@ -539,7 +538,7 @@ impl Config {
   pub fn generate_default_config(format: &str, path: &Path) -> Result<()> {
     // Get template from the templates module
     let config_content = crate::config::templates::get_template(format)
-      .map_err(|e| anyhow::anyhow!("{}", e))?;
+      .map_err(|e| anyhow::anyhow!("{e}"))?;
 
     fs::write(path, config_content).with_context(|| {
       format!("Failed to write default config to {}", path.display())

--- a/ndg/src/html/template.rs
+++ b/ndg/src/html/template.rs
@@ -30,7 +30,7 @@ pub fn render(
     .file_stem()
     .and_then(|s| s.to_str())
     .unwrap_or("default");
-  let specific_template_name = format!("{}.html", file_stem);
+  let specific_template_name = format!("{file_stem}.html");
 
   // Try to load file-specific template first, then fall back to default
   let template_content = if let Ok(specific_content) = get_template_content(
@@ -38,10 +38,10 @@ pub fn render(
     &specific_template_name,
     "", // no fallback for specific templates
   ) {
-    if !specific_content.is_empty() {
-      specific_content
-    } else {
+    if specific_content.is_empty() {
       get_template_content(config, "default.html", DEFAULT_TEMPLATE)?
+    } else {
+      specific_content
     }
   } else {
     get_template_content(config, "default.html", DEFAULT_TEMPLATE)?

--- a/ndg/src/manpage/options.rs
+++ b/ndg/src/manpage/options.rs
@@ -576,7 +576,7 @@ fn process_roles(text: &str) -> String {
 
   let options = MarkdownOptions::default();
   let processor = MarkdownProcessor::new(options);
-  process_role_markup(text, processor.manpage_urls())
+  process_role_markup(text, processor.manpage_urls(), true)
 }
 
 /// Process command prompts ($ command)


### PR DESCRIPTION
Adds for MyST-style autolinks by introducing a new preprocessing step for MyST autolinks, enhance the `{option}` role to optionally generate links to `options.html`. For example:

```
# This will create a link to https://github.com/notashelf/nvf
# with the link as the link text and the destination.
[](https://github.com/notashelf/nvf)
```

and introduces a special syntax item for linking items in the options page without typing
the full page reference. This can be invoked by prefixing the option with `#opt-` followed by the option itself. For example:

```
# This
[](#opt-boot.loader.systemd-boot.enable) -> /options.html#boot.loader.systemd-boot.enable
```

I've also introduced a configuration file toggle for disabling automatic linking of option roles to the options page. It is enabled by default, but can be disabled from the callsites of `process_role_markup()`.




Signed-off-by: NotAShelf <raf@notashelf.dev>
Change-Id: I6a6a6964cd863701cc074b2b9689882a7a8acd67