### PR TITLE
ndg-commonmark: improve documentation

### DIFF
--- a/ndg-commonmark/src/lib.rs
+++ b/ndg-commonmark/src/lib.rs
@@ -1,10 +1,45 @@
 //! # NDG-Commonmark
 //!
-//! This is a high-performance Markdown processor designed for Nix, `NixOS` and
-//! Nixpkgs documentation featuring AST-based processing with role markup,
-//! autolinks, GFM support and more.
+//! NDG-Commonmark is a high-performance, extensible Markdown processor for Nix,
+//! NixOS, and Nixpkgs projects. It is the AST-based Markdown parser and
+//! converter component that is capable of processing Nixpkgs-flavored
+//! Commonmark, optionally with additional flavors such as Github Flavored
+//! Markdown (GFM).
 //!
-//! ## Processing
+//! This crate is designed to be a robust, extensible and customizable
+//! cornerstone in the Nix ecosystem designed for usage in documentation tools
+//! and static site generators that would like to integrate Nix module systems
+//! as a first-class citizen while keeping convenient Markdown features under
+//! their belt for advanced use.
+//!
+//! As NDG-Commonmark aims to replace tools such as nixos-render-docs, its
+//! syntax is a superset of the Nixpkgs-flavored Commonmark, with optional
+//! feature flags for controlling what features are available. It is fully
+//! possible to use NDG-Commonmark as a drop-in replacement for
+//! nixos-render-docs.
+//!
+//! ## Overview
+//!
+//! - **AST-based processing**: Enables advanced transformations and custom
+//!   syntax extensions.
+//! - **Role markup and Nix-specific features**: Support for `{command}` blocks,
+//!   option references, file includes, and more.
+//! - **Syntax highlighting**: Modern, themeable code highlighting for many
+//!   languages.
+//! - **Extensible**: Use feature flags to enable only the extensions you need.
+//!
+//! ## Usage Examples
+//!
+//! The following examples are designed to show how to use this crate as a
+//! library. They demonstrate how to process Markdown to HTML, extract document
+//! structure, and configure the processor for different use cases.
+//!
+//! ### Basic Markdown Processing
+//!
+//! This example demonstrates how to convert a Markdown string to HTML using a
+//! preset configuration. The [`process_markdown_string`] function is a
+//! convenience wrapper for common use cases. The result contains the rendered
+//! HTML, the document title, and extracted headers.
 //!
 //! ```rust
 //! use ndg_commonmark::{ProcessorPreset, process_markdown_string};
@@ -17,7 +52,12 @@
 //! println!("Title: {:?}", result.title);
 //! ```
 //!
-//! ## API
+//! ### Custom Processor and Options
+//!
+//! For more control, you can create a [`MarkdownProcessor`] with custom
+//! options. This allows you to enable or disable features such as GFM, Nixpkgs
+//! extensions, and syntax highlighting. The processor exposes methods to render
+//! Markdown, extract headers, and more.
 //!
 //! ```rust
 //! use ndg_commonmark::{MarkdownOptions, MarkdownProcessor};
@@ -30,7 +70,11 @@
 //! println!("Headers: {:?}", result.headers);
 //! ```
 //!
-//! ## Builder Pattern
+//! ### Builder Pattern for Configuration
+//!
+//! The builder pattern allows you to construct [`MarkdownOptions`] with
+//! fine-grained control over all features. This is useful for applications that
+//! need to dynamically configure the Markdown processor.
 //!
 //! ```rust
 //! use ndg_commonmark::{MarkdownOptionsBuilder, MarkdownProcessor};
@@ -47,7 +91,7 @@
 
 pub mod processor;
 pub mod syntax;
-mod types;
+pub mod types;
 pub mod utils;
 
 // Re-export main API

--- a/ndg/src/cli.rs
+++ b/ndg/src/cli.rs
@@ -4,8 +4,9 @@ use clap::{Command, CommandFactory, Parser, Subcommand};
 
 /// Command line interface for ndg
 #[derive(Parser, Debug)]
-#[command(author, version, about = "Nix Documentation Generator")]
+#[command(author, version, about = "NDG: Not a Docs Generator")]
 pub struct Cli {
+  /// Subcommand to execute (see [`Commands`])
   #[command(subcommand)]
   pub command: Option<Commands>,
 
@@ -18,6 +19,7 @@ pub struct Cli {
   pub config_file: Option<PathBuf>,
 }
 
+/// All supported subcommands for the ndg CLI.
 #[derive(Subcommand, Debug)]
 pub enum Commands {
   /// Initialize a new NDG configuration file
@@ -26,7 +28,7 @@ pub enum Commands {
     #[arg(short, long, default_value = "ndg.toml")]
     output: PathBuf,
 
-    /// Format of the configuration file (toml or json)
+    /// Format of the configuration file.
     #[arg(short = 'F', long, default_value = "toml", value_parser = ["toml", "json"])]
     format: String,
 
@@ -35,47 +37,47 @@ pub enum Commands {
     force: bool,
   },
 
-  /// Export default templates to a directory for customization
+  /// Export default templates to a directory for customization.
   ExportTemplates {
-    /// Output directory for template files
+    /// Output directory for template files.
     #[arg(short, long, default_value = "templates")]
     output_dir: PathBuf,
 
-    /// Overwrite existing files
+    /// Whether to overwrite existing files.
     #[arg(long)]
     force: bool,
   },
 
-  /// Generate shell completions and manpages
+  /// Generate shell completions and manpages.
   Generate {
-    /// Directory to output generated files
+    /// Directory to output generated files.
     #[arg(short, long, default_value = "dist")]
     output_dir: PathBuf,
 
-    /// Only generate shell completions
+    /// Only generate shell completions.
     #[arg(long)]
     completions_only: bool,
 
-    /// Only generate manpage
+    /// Only generate manpage.
     #[arg(long)]
     manpage_only: bool,
   },
 
-  /// Process documentation and generate HTML
+  /// Process documentation and generate HTML.
   Html {
-    /// Path to the directory containing markdown files
+    /// Path to the directory containing markdown files.
     #[arg(short, long)]
     input_dir: Option<PathBuf>,
 
-    /// Output directory for generated documentation
+    /// Output directory for generated documentation.
     #[arg(short, long)]
     output_dir: Option<PathBuf>,
 
-    /// Number of threads to use for parallel processing
+    /// Number of threads to use for parallel processing.
     #[arg(short = 'p', long = "jobs")]
     jobs: Option<usize>,
 
-    /// Path to custom template file
+    /// Path to custom template file.
     #[arg(short, long)]
     template: Option<PathBuf>,
 
@@ -101,7 +103,7 @@ pub enum Commands {
     #[arg(short = 'T', long)]
     title: Option<String>,
 
-    /// Footer text for the documentation
+    /// Footer text for the documentation.
     #[arg(short = 'f', long)]
     footer: Option<String>,
 
@@ -110,30 +112,30 @@ pub enum Commands {
     #[arg(short = 'j', long)]
     module_options: Option<PathBuf>,
 
-    /// Depth of parent categories in options TOC
+    /// Depth of parent categories in options section in the sidebar.
     #[arg(long = "options-depth", value_parser = clap::value_parser!(usize))]
     options_toc_depth: Option<usize>,
 
-    /// Path to manpage URL mappings JSON file
+    /// Path to manpage URL mappings JSON file.
     #[arg(long = "manpage-urls")]
     manpage_urls: Option<PathBuf>,
 
-    /// Whether to generate search functionality
+    /// Whether to generate search data and render relevant components.
     #[arg(short = 'S', long = "generate-search")]
     generate_search: Option<bool>,
 
-    /// Whether to enable syntax highlighting for code blocks
+    /// Whether to enable syntax highlighting for code blocks.
     #[arg(long = "highlight-code")]
     highlight_code: Option<bool>,
 
-    /// GitHub revision for linking to source files (defaults to 'local')
-    #[arg(long)]
+    /// GitHub revision for linking to source files.
+    #[arg(long, default_value = "local")]
     revision: Option<String>,
   },
 
-  /// Generate manpage from options
+  /// Generate manpage from options.
   Manpage {
-    /// Path to a JSON file containing module options
+    /// Path to a JSON file containing module options.
     #[arg(short = 'j', long, required = true)]
     module_options: PathBuf,
 
@@ -160,11 +162,14 @@ pub enum Commands {
 }
 
 impl Cli {
+  /// Parse command line arguments into a [`Cli`] struct.
   #[must_use]
   pub fn parse_args() -> Self {
     Self::parse()
   }
 
+  /// Return a [`clap::Command`] for the CLI, for use in shell completions and
+  /// manpage generation.
   #[must_use]
   pub fn command() -> Command {
     <Self as CommandFactory>::command()

--- a/ndg/src/completion.rs
+++ b/ndg/src/completion.rs
@@ -6,7 +6,8 @@ use clap_mangen::Man;
 
 use crate::cli::Cli;
 
-/// Generates shell completions for the ndg CLI.
+/// Generate shell completions for the ndg CLI and write them to the specified
+/// output directory.
 pub fn generate_comp<P: AsRef<Path>>(output_dir: P) -> Result<()> {
   let output_dir = output_dir.as_ref();
   fs::create_dir_all(output_dir)?;
@@ -22,7 +23,8 @@ pub fn generate_comp<P: AsRef<Path>>(output_dir: P) -> Result<()> {
   Ok(())
 }
 
-/// Generates a manpage for the ndg CLI.
+/// Generate a manual page for the ndg CLI and write it to the specified output
+/// directory.
 pub fn generate_manpage<P: AsRef<Path>>(output_dir: P) -> Result<()> {
   let output_dir = output_dir.as_ref();
   fs::create_dir_all(output_dir)?;
@@ -42,7 +44,8 @@ pub fn generate_manpage<P: AsRef<Path>>(output_dir: P) -> Result<()> {
   Ok(())
 }
 
-/// Generates both shell completions and a manpage for the ndg CLI.
+/// Generate both shell completions and a manpage for the ndg CLI, writing them
+/// to the specified output directory.
 pub fn generate_all<P: AsRef<Path>>(output_dir: P) -> Result<()> {
   let output_dir = output_dir.as_ref();
 

--- a/ndg/src/lib.rs
+++ b/ndg/src/lib.rs
@@ -1,8 +1,36 @@
-//! NDG's internal API exposed in order to be used in unit testing. While this
-//! could be useful for end users, end users should opt in to consume
-//! ndg-commonmark directly. This interface is for testing purposes ONLY and
-//! will not make any guarantees of stability.
-
+//! # NDG: Not a Docs Generator
+//!
+//! `ndg` is a fast, customizable documentation generator for Nix, NixOS, and
+//! Nixpkgs module systems. It converts Markdown and Nix module options into
+//! HTML and manpages, supporting Nixpkgs-flavored CommonMark, automatic table
+//! of contents, search, multi-threading, and fully customizable templates.
+//!
+//! ## Features
+//! - Markdown to HTML and Manpage conversion with Nixpkgs-flavored CommonMark
+//!   support
+//! - Automatic table of contents and heading anchors
+//! - Search functionality across documents
+//! - Nix module options support for generating documentation from
+//!   `options.json`
+//! - Fully customizable templates and stylesheets
+//! - Multi-threading for fast generation of large documentation sets
+//! - Seamless integration with Nix workflows
+//!
+//! ## Usage
+//!
+//! Be advised that NDG's internal API is exposed ONLY in order to be used in
+//! our unit tests. While this API could be useful to end users, e.g., by
+//! exposing some wrapper functions, [ndg-commonmark](../ndg_commonmark)'s own
+//! API should be preferred for library use. This interface is for
+//! testing purposes ONLY and will not make any guarantees of stability between
+//! versions.
+//!
+//! ### CLI Use
+//!
+//! [Github Repository]: https://github.com/feel-co/ndg
+//! NDG is primarily designed as a CLI utility, and its documentation is located
+//! in the [Github repository]. Please refer to the project README for more
+//! information about the project, installing NDG, and CLI usage.
 pub mod cli;
 pub mod completion;
 pub mod config;


### PR DESCRIPTION
Better docs across the board. This PR improves the rendered documentation, code comments, and public API clarity across several modules in the codebase. Hopefully ndg's API, while not meant for public use, is a bit more maintainable and user-friendly with the new improved doc comments. Also includes some VERY MINOR code cleanup and public visibility adjustments.

Signed-off-by: NotAShelf <raf@notashelf.dev>
Change-Id: I6a6a69649dc8c873d0df95698c0d17e508497617