### PR TITLE
style: darken surface color to improve readability

### DIFF
--- a/ndg/templates/default.css
+++ b/ndg/templates/default.css
@@ -119,7 +119,7 @@
   :root {
     /* Dark Mode Colors  */
     --bg-color: var(--neutral-950);
-    --bg-surface: #4a73b5ff;
+    --bg-surface: #304b76ff;
     --bg-surface-2: #334155;
     --text-color: #e2e8f0;
     --text-muted: #94a3b8;


### PR DESCRIPTION
darkened the color of bg-surface just enough to pass [WCAG](https://www.wcag.com/resource/what-is-wcag/#The_Three_Levels_of_WCAG_Conformance_A_AA_and_AAA) conformance level AAA (a.k.a I can read without burning my eyes out now)

before: 
<img width="780" height="204" alt="image" src="https://github.com/user-attachments/assets/610cd7dc-b3ee-462f-8f40-4a4bf4acd2ec" />

after: 
<img width="780" height="204" alt="image" src="https://github.com/user-attachments/assets/4633f1a8-feef-41d2-8cfe-b476550fd5a5" />
