### PR TITLE
ndg-config: add directory grouping and count badge options for sidebar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,13 @@ changes.
 
 ### Added
 
+- Optional `sidebar.group_by_dir` option to group sidebar items by parent
+  directory. When enabled, pages under the same subdirectory are collapsed
+  under a collapsible heading named after that directory. Root-level pages are
+  always shown flat. Groups are sorted alphabetically with a configurable
+  ordering algorithm. Configure via `sidebar.group_by_dir = true` in
+  `ndg.toml`. The `sidebar.show_group_counts` option (defaulting to `true`)
+  controls whether item count badges are displayed on each directory group.
 - Optional `serve` feature flag for local development server. When enabled, pass
   `--serve` and optionally `--serve-port` to `ndg html` to automatically start a
   local web server after documentation generation completes.

--- a/crates/ndg-config/src/sidebar.rs
+++ b/crates/ndg-config/src/sidebar.rs
@@ -104,6 +104,14 @@ pub struct SidebarConfig {
   #[serde(default)]
   pub ordering: SidebarOrdering,
 
+  /// Whether to group sidebar items by their parent directory.
+  ///
+  /// When enabled, pages that share a parent directory are grouped under a
+  /// collapsible heading named after that directory. Pages at the root of
+  /// `input_dir` are never grouped.
+  #[serde(default)]
+  pub group_by_dir: bool,
+
   /// Pattern-based matching rules for sidebar items.
   #[serde(default)]
   pub matches: Vec<SidebarMatch>,
@@ -831,6 +839,7 @@ mod tests {
       numbered:             true,
       number_special_files: false,
       ordering:             SidebarOrdering::Custom,
+      group_by_dir:         false,
       options:              None,
       matches:              vec![
         SidebarMatch {
@@ -867,6 +876,7 @@ mod tests {
       numbered:             false,
       number_special_files: false,
       ordering:             SidebarOrdering::Alphabetical,
+      group_by_dir:         false,
       options:              None,
       matches:              vec![
         SidebarMatch {
@@ -897,6 +907,7 @@ mod tests {
       numbered:             false,
       number_special_files: false,
       ordering:             SidebarOrdering::Alphabetical,
+      group_by_dir:         false,
       options:              None,
       matches:              vec![SidebarMatch {
         path:      Some(PathMatch::exact("test.md".to_string())),
@@ -921,6 +932,7 @@ mod tests {
       numbered:             false,
       number_special_files: false,
       ordering:             SidebarOrdering::Alphabetical,
+      group_by_dir:         false,
       options:              None,
       matches:              vec![SidebarMatch {
         path:      Some(PathMatch::exact("test.md".to_string())),

--- a/crates/ndg-config/src/sidebar.rs
+++ b/crates/ndg-config/src/sidebar.rs
@@ -112,6 +112,12 @@ pub struct SidebarConfig {
   #[serde(default)]
   pub group_by_dir: bool,
 
+  /// Whether to show item count badges on directory groups in the sidebar.
+  ///
+  /// Only has effect when `group_by_dir` is `true`. Defaults to `true`.
+  #[serde(default = "default_true")]
+  pub show_group_counts: bool,
+
   /// Pattern-based matching rules for sidebar items.
   #[serde(default)]
   pub matches: Vec<SidebarMatch>,
@@ -119,6 +125,10 @@ pub struct SidebarConfig {
   /// Options sidebar configuration.
   #[serde(default)]
   pub options: Option<OptionsConfig>,
+}
+
+const fn default_true() -> bool {
+  true
 }
 
 impl SidebarConfig {
@@ -840,6 +850,7 @@ mod tests {
       number_special_files: false,
       ordering:             SidebarOrdering::Custom,
       group_by_dir:         false,
+      show_group_counts:    true,
       options:              None,
       matches:              vec![
         SidebarMatch {
@@ -877,6 +888,7 @@ mod tests {
       number_special_files: false,
       ordering:             SidebarOrdering::Alphabetical,
       group_by_dir:         false,
+      show_group_counts:    true,
       options:              None,
       matches:              vec![
         SidebarMatch {
@@ -908,6 +920,7 @@ mod tests {
       number_special_files: false,
       ordering:             SidebarOrdering::Alphabetical,
       group_by_dir:         false,
+      show_group_counts:    true,
       options:              None,
       matches:              vec![SidebarMatch {
         path:      Some(PathMatch::exact("test.md".to_string())),
@@ -933,6 +946,7 @@ mod tests {
       number_special_files: false,
       ordering:             SidebarOrdering::Alphabetical,
       group_by_dir:         false,
+      show_group_counts:    true,
       options:              None,
       matches:              vec![SidebarMatch {
         path:      Some(PathMatch::exact("test.md".to_string())),

--- a/crates/ndg-html/src/template.rs
+++ b/crates/ndg-html/src/template.rs
@@ -111,7 +111,7 @@ fn setup_tera_templates(
     .as_ref()
     .or(config.template_path.as_ref())
     .map_or_else(|| "default".to_string(), |p| p.display().to_string());
-  let cache_key = format!("{}:{}", template_key, main_template_name);
+  let cache_key = format!("{template_key}:{main_template_name}");
 
   // Check cache first
   {
@@ -1069,7 +1069,7 @@ fn render_nav_item(output: &mut String, item: &NavItem) {
 /// Items at the root (empty `rel_dir`) are rendered flat. Items in a
 /// subdirectory are wrapped in a collapsible `<details>` element with a
 /// `<summary>` label derived from the directory name.
-fn render_grouped(output: &mut String, items: Vec<NavItem>) {
+fn render_grouped(output: &mut String, items: Vec<NavItem>, show_counts: bool) {
   use std::collections::BTreeMap;
 
   // Separate root items from directory-grouped items.
@@ -1111,11 +1111,15 @@ fn render_grouped(output: &mut String, items: Vec<NavItem>) {
       }
     };
     let count = group_items.len();
+    let count_badge = if show_counts {
+      format!("<span class=\"sidebar-dir-count\">{count}</span>")
+    } else {
+      String::new()
+    };
     let _ = writeln!(
       output,
       "<li class=\"sidebar-dir-group\"><details open><summary><span \
-       class=\"sidebar-dir-label\">{label}</span><span \
-       class=\"sidebar-dir-count\">{count}</span></summary><ul>"
+       class=\"sidebar-dir-label\">{label}</span>{count_badge}</summary><ul>"
     );
 
     for item in group_items {
@@ -1328,6 +1332,9 @@ fn generate_doc_nav(config: &Config, current_file_rel_path: &Path) -> String {
       let group_by_dir =
         config.sidebar.as_ref().is_some_and(|s| s.group_by_dir);
 
+      let show_group_counts =
+        config.sidebar.as_ref().is_some_and(|s| s.show_group_counts);
+
       // Render navigation items
       if should_number_special {
         // Combine special and regular items with unified numbering
@@ -1340,7 +1347,7 @@ fn generate_doc_nav(config: &Config, current_file_rel_path: &Path) -> String {
         }
 
         if group_by_dir {
-          render_grouped(&mut doc_nav, all_items);
+          render_grouped(&mut doc_nav, all_items, show_group_counts);
         } else {
           // Render all items flat
           for item in all_items {
@@ -1358,7 +1365,7 @@ fn generate_doc_nav(config: &Config, current_file_rel_path: &Path) -> String {
         }
 
         if group_by_dir {
-          render_grouped(&mut doc_nav, nav_items);
+          render_grouped(&mut doc_nav, nav_items, show_group_counts);
         } else {
           // Render regular entries with optional numbering
           for item in nav_items {

--- a/crates/ndg-html/src/template.rs
+++ b/crates/ndg-html/src/template.rs
@@ -1040,8 +1040,90 @@ fn load_template_content(
 struct NavItem {
   path:     String,
   title:    String,
+  /// Parent directory relative to `input_dir` ().
+  rel_dir:  String, // empty string for root items
   position: Option<usize>,
   number:   Option<usize>,
+}
+
+/// Render a single navigation item as a `<li>` element, with optional
+/// numbering.
+fn render_nav_item(output: &mut String, item: &NavItem) {
+  if let Some(num) = item.number {
+    let _ = writeln!(
+      output,
+      "<li><a href=\"{}\">{num}. {}</a></li>",
+      item.path, item.title
+    );
+  } else {
+    let _ = writeln!(
+      output,
+      "<li><a href=\"{}\">{}</a></li>",
+      item.path, item.title
+    );
+  }
+}
+
+/// Render navigation items grouped by their parent directory.
+///
+/// Items at the root (empty `rel_dir`) are rendered flat. Items in a
+/// subdirectory are wrapped in a collapsible `<details>` element with a
+/// `<summary>` label derived from the directory name.
+fn render_grouped(output: &mut String, items: Vec<NavItem>) {
+  use std::collections::BTreeMap;
+
+  // Separate root items from directory-grouped items.
+  let mut root_items: Vec<NavItem> = Vec::new();
+  // BTreeMap preserves directory insertion order (sorted by dir name).
+  let mut dir_groups: BTreeMap<String, Vec<NavItem>> = BTreeMap::new();
+
+  for item in items {
+    if item.rel_dir.is_empty() {
+      root_items.push(item);
+    } else {
+      // Use only the first path component as the group label so that
+      // `features/foo/bar.md` is still grouped under `features`.
+      let top_dir = std::path::Path::new(&item.rel_dir)
+        .components()
+        .next()
+        .and_then(|c| c.as_os_str().to_str())
+        .unwrap_or(&item.rel_dir)
+        .to_string();
+      dir_groups.entry(top_dir).or_default().push(item);
+    }
+  }
+
+  // Render root items flat.
+  for item in root_items {
+    render_nav_item(output, &item);
+  }
+
+  // Render each directory group as a collapsible block.
+  for (dir_name, group_items) in dir_groups {
+    // Capitalise the first letter of the directory name for the label.
+    let label = {
+      let mut chars = dir_name.chars();
+      match chars.next() {
+        None => dir_name.clone(),
+        Some(first) => {
+          first.to_uppercase().collect::<String>() + chars.as_str()
+        },
+      }
+    };
+    let count = group_items.len();
+    let _ = writeln!(
+      output,
+      "<li class=\"sidebar-dir-group\"><details open><summary><span \
+       class=\"sidebar-dir-label\">{label}</span><span \
+       class=\"sidebar-dir-count\">{count}</span></summary><ul>"
+    );
+
+    for item in group_items {
+      render_nav_item(output, &item);
+    }
+
+    let _ = writeln!(output, "</ul></details></li>");
+  }
 }
 
 /// Generate the document navigation HTML
@@ -1128,6 +1210,11 @@ fn generate_doc_nav(config: &Config, current_file_rel_path: &Path) -> String {
           Some(NavItem {
             path: target_path,
             title: display_title,
+            rel_dir: rel_doc_path
+              .parent()
+              .and_then(|p| p.to_str())
+              .unwrap_or("")
+              .to_string(),
             position,
             number: None,
           })
@@ -1202,6 +1289,11 @@ fn generate_doc_nav(config: &Config, current_file_rel_path: &Path) -> String {
           Some(NavItem {
             path:     target_path,
             title:    display_title,
+            rel_dir:  rel_doc_path
+              .parent()
+              .and_then(|p| p.to_str())
+              .unwrap_or("")
+              .to_string(),
             position: None,
             number:   None,
           })
@@ -1233,6 +1325,9 @@ fn generate_doc_nav(config: &Config, current_file_rel_path: &Path) -> String {
         .as_ref()
         .is_some_and(|s| s.numbered && s.number_special_files);
 
+      let group_by_dir =
+        config.sidebar.as_ref().is_some_and(|s| s.group_by_dir);
+
       // Render navigation items
       if should_number_special {
         // Combine special and regular items with unified numbering
@@ -1244,25 +1339,17 @@ fn generate_doc_nav(config: &Config, current_file_rel_path: &Path) -> String {
           item.number = Some(idx + 1);
         }
 
-        // Render all items
-        for item in all_items {
-          if let Some(num) = item.number {
-            let _ = writeln!(
-              doc_nav,
-              "<li><a href=\"{}\">{num}. {}</a></li>",
-              item.path, item.title
-            );
-          } else {
-            let _ = writeln!(
-              doc_nav,
-              "<li><a href=\"{}\">{}</a></li>",
-              item.path, item.title
-            );
+        if group_by_dir {
+          render_grouped(&mut doc_nav, all_items);
+        } else {
+          // Render all items flat
+          for item in all_items {
+            render_nav_item(&mut doc_nav, &item);
           }
         }
       } else {
         // Render special entries first without numbering
-        for item in special_nav_items {
+        for item in &special_nav_items {
           let _ = writeln!(
             doc_nav,
             "<li><a href=\"{}\">{}</a></li>",
@@ -1270,20 +1357,12 @@ fn generate_doc_nav(config: &Config, current_file_rel_path: &Path) -> String {
           );
         }
 
-        // Render regular entries with optional numbering
-        for item in nav_items {
-          if let Some(num) = item.number {
-            let _ = writeln!(
-              doc_nav,
-              "<li><a href=\"{}\">{num}. {}</a></li>",
-              item.path, item.title
-            );
-          } else {
-            let _ = writeln!(
-              doc_nav,
-              "<li><a href=\"{}\">{}</a></li>",
-              item.path, item.title
-            );
+        if group_by_dir {
+          render_grouped(&mut doc_nav, nav_items);
+        } else {
+          // Render regular entries with optional numbering
+          for item in nav_items {
+            render_nav_item(&mut doc_nav, &item);
           }
         }
       }

--- a/crates/ndg-html/tests/html_template.rs
+++ b/crates/ndg-html/tests/html_template.rs
@@ -549,6 +549,7 @@ fn sidebar_numbering_excludes_special_files() {
     number_special_files: false, // Default behavior
     ordering:             ndg_config::sidebar::SidebarOrdering::Alphabetical,
     group_by_dir:         false,
+    show_group_counts:    true,
     matches:              vec![],
     options:              None,
   });
@@ -607,6 +608,7 @@ fn sidebar_numbering_special_files_included() {
     number_special_files: true, // enable numbering for special files
     ordering:             ndg_config::sidebar::SidebarOrdering::Alphabetical,
     group_by_dir:         false,
+    show_group_counts:    true,
     matches:              vec![],
     options:              None,
   });
@@ -671,6 +673,7 @@ fn sidebar_numbering_disabled_no_numbers() {
     number_special_files: false,
     ordering:             ndg_config::sidebar::SidebarOrdering::Alphabetical,
     group_by_dir:         false,
+    show_group_counts:    true,
     matches:              vec![],
     options:              None,
   });

--- a/crates/ndg-html/tests/html_template.rs
+++ b/crates/ndg-html/tests/html_template.rs
@@ -548,6 +548,7 @@ fn sidebar_numbering_excludes_special_files() {
     numbered:             true,
     number_special_files: false, // Default behavior
     ordering:             ndg_config::sidebar::SidebarOrdering::Alphabetical,
+    group_by_dir:         false,
     matches:              vec![],
     options:              None,
   });
@@ -605,6 +606,7 @@ fn sidebar_numbering_special_files_included() {
     numbered:             true,
     number_special_files: true, // enable numbering for special files
     ordering:             ndg_config::sidebar::SidebarOrdering::Alphabetical,
+    group_by_dir:         false,
     matches:              vec![],
     options:              None,
   });
@@ -668,6 +670,7 @@ fn sidebar_numbering_disabled_no_numbers() {
     numbered:             false, // Numbering disabled
     number_special_files: false,
     ordering:             ndg_config::sidebar::SidebarOrdering::Alphabetical,
+    group_by_dir:         false,
     matches:              vec![],
     options:              None,
   });

--- a/crates/ndg-templates/templates/default.css
+++ b/crates/ndg-templates/templates/default.css
@@ -2469,3 +2469,71 @@ h6:hover .copy-link {
     }
   }
 }
+
+/* Sidebar directory groups */
+.sidebar-dir-group {
+  list-style: none;
+  margin-bottom: var(--space-1);
+
+  > details {
+    > summary {
+      display: flex;
+      align-items: center;
+      gap: var(--space-2);
+      padding: var(--space-2) var(--space-3);
+      border-radius: var(--radius-md);
+      cursor: pointer;
+      user-select: none;
+      font-size: 0.8125rem;
+      font-weight: 600;
+      color: var(--text-muted);
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+      list-style: none;
+      transition:
+        background-color var(--transition-fast),
+        color var(--transition-fast);
+
+      &::-webkit-details-marker {
+        display: none;
+      }
+
+      &::before {
+        content: "▶";
+        font-size: 0.625rem;
+        transition: transform var(--transition-fast);
+        flex-shrink: 0;
+      }
+
+      &:hover {
+        background-color: var(--sidebar-hover);
+        color: var(--text-color);
+      }
+    }
+
+    &[open] > summary::before {
+      transform: rotate(90deg);
+    }
+
+    > ul {
+      margin: var(--space-1) 0 var(--space-1) var(--space-4);
+      padding-left: var(--space-2);
+      border-left: 2px solid var(--border-color);
+    }
+  }
+
+  .sidebar-dir-count {
+    font-size: 0.7rem;
+    font-weight: 500;
+    background-color: var(--sidebar-active);
+    color: var(--text-muted);
+    border-radius: 9999px;
+    padding: 0 var(--space-2);
+    line-height: 1.6;
+    margin-left: auto;
+  }
+
+  .sidebar-dir-label {
+    flex: 1;
+  }
+}


### PR DESCRIPTION
Introduces a new "group by directory" feature for the sidebar navigation, allowing sidebar items to be grouped under collapsible headings based on their parent directory. Consequentially it also adds support for showing item count badges on these directory groups, because it looked terrible with those counters in the document tree. 