### PR TITLE
ndg: tags field to frontmatter; support for wiki features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,14 @@ changes.
   dest  = "apple-touch-icon.png"
   rel   = "apple-touch-icon"
   ```
+- Per-page `tags` frontmatter support for Markdown documents. Tags are injected
+  as `<meta name="keywords">` and override the global `meta.tags.keywords`
+  configuration for that page. Useful for adding page-specific categorization
+  beyond the global site-wide keywords.
+- Wiki/Obsidian-style link support (`[[page]]` and `[[name|url]]`) via the
+  `ndg-commonmark/wiki` feature flag. Converts double-bracket links to HTML
+  anchors with appropriate CSS classes (`wikilink` for external, `obsidian-link`
+  for internal links).
 - Optional `sidebar.group_by_dir` option to group sidebar items by parent
   directory. When enabled, pages under the same subdirectory are collapsed under
   a collapsible heading named after that directory. Root-level pages are always

--- a/crates/ndg-html/src/template.rs
+++ b/crates/ndg-html/src/template.rs
@@ -36,6 +36,7 @@ struct PageContext {
   author:      Option<String>,
   template:    Option<String>,
   toc:         Option<bool>,
+  tags:        Option<Vec<String>>,
   extra:       serde_json::Value,
 }
 
@@ -48,6 +49,7 @@ impl PageContext {
         author:      None,
         template:    None,
         toc:         None,
+        tags:        None,
         extra:       serde_json::Value::Null,
       };
     };
@@ -62,6 +64,7 @@ impl PageContext {
       author: fm.author.clone(),
       template: fm.template.clone(),
       toc: fm.toc,
+      tags: fm.tags.clone(),
       extra,
     }
   }
@@ -333,6 +336,9 @@ fn generate_meta_tags_html(
     }
     if let Some(ref author) = fm.author {
       merged.insert("author".to_owned(), author.clone());
+    }
+    if let Some(ref tags) = fm.tags {
+      merged.insert("keywords".to_owned(), tags.join(", "));
     }
   }
 

--- a/crates/ndg-utils/src/markdown.rs
+++ b/crates/ndg-utils/src/markdown.rs
@@ -42,6 +42,10 @@ pub struct PageFrontmatter {
   /// When `false`, suppresses the table of contents for this page.
   pub toc: Option<bool>,
 
+  /// Per-page tags. Injected as `<meta name="keywords">` and override the
+  /// global `meta.tags.keywords` for this page.
+  pub tags: Option<Vec<String>>,
+
   /// Arbitrary user-defined data. Accessible in templates as
   /// `{{ page.extra.key }}`.
   pub extra: Option<toml::Table>,

--- a/ndg-commonmark/Cargo.toml
+++ b/ndg-commonmark/Cargo.toml
@@ -18,8 +18,9 @@ path = "src/lib.rs"
 [features]
 default      = [ "ndg-flavored", "syntastica" ]
 gfm          = [  ]
-ndg-flavored = [ "gfm", "nixpkgs" ]
+ndg-flavored = [ "gfm", "nixpkgs", "wiki" ]
 nixpkgs      = [  ]
+wiki         = [  ]
 
 # Feature flags for Syntax highlighting.
 # Syntastica requires the "most" feature flag if we need Nix support, and Syntect

--- a/ndg-commonmark/src/processor/core.rs
+++ b/ndg-commonmark/src/processor/core.rs
@@ -310,6 +310,10 @@ impl MarkdownProcessor {
       );
     }
 
+    if cfg!(feature = "wiki") {
+      processed = super::extensions::process_wikilinks(&processed);
+    }
+
     (processed, included_files)
   }
 

--- a/ndg-commonmark/src/processor/extensions.rs
+++ b/ndg-commonmark/src/processor/extensions.rs
@@ -1255,6 +1255,103 @@ fn extract_url_from_html(url_or_html: &str) -> &str {
   url_or_html
 }
 
+/// Process wikilinks and Obsidian-style links in markdown content.
+///
+/// Converts:
+///
+/// - `[[page]]` (Obsidian link) -> `[page](page.html)`
+/// - `[[name|url]]` (Wiki link) -> `[name](url)`
+///
+/// Being code-block aware to avoid processing inside fenced code blocks.
+///
+/// # Arguments
+///
+/// * `content` - The markdown content to process
+///
+/// # Returns
+///
+/// The processed markdown with wiki/Obsidian links converted to HTML
+#[cfg(feature = "wiki")]
+#[must_use]
+pub fn process_wikilinks(content: &str) -> String {
+  use crate::utils::codeblock::FenceTracker;
+
+  let mut result = String::with_capacity(content.len());
+  let lines = content.lines();
+  let mut tracker = FenceTracker::new();
+
+  for line in lines {
+    tracker = tracker.process_line(line);
+
+    if tracker.in_code_block() {
+      result.push_str(line);
+    } else {
+      result.push_str(&process_line_wikilinks(line));
+    }
+    result.push('\n');
+  }
+
+  result.trim_end().to_string()
+}
+
+/// Process wikilinks in a single line.
+#[cfg(feature = "wiki")]
+fn process_line_wikilinks(line: &str) -> String {
+  let mut result = String::with_capacity(line.len());
+  let mut chars = line.chars().peekable();
+
+  while let Some(ch) = chars.next() {
+    if ch == '[' && chars.peek() == Some(&'[') {
+      chars.next();
+
+      let mut inner = String::new();
+      let mut found_double_close = false;
+
+      while let Some(&next_ch) = chars.peek() {
+        chars.next();
+        if next_ch == ']' && chars.peek() == Some(&']') {
+          chars.next();
+          found_double_close = true;
+          break;
+        }
+        inner.push(next_ch);
+      }
+
+      if found_double_close {
+        if inner.is_empty() {
+          result.push_str("[[]]");
+        } else if inner.contains('|') {
+          let parts: Vec<&str> = inner.splitn(2, '|').collect();
+          let name = parts[0].trim();
+          let url = parts.get(1).unwrap_or(&name).trim();
+          let escaped_name = encode_text(name);
+          let escaped_url = encode_text(url);
+          let _ = write!(
+            result,
+            "<a href=\"{escaped_url}\" class=\"wikilink\">{escaped_name}</a>"
+          );
+        } else {
+          let page = inner.trim();
+          let escaped_page = encode_text(page);
+          let link_target = format!("{page}.html");
+          let _ = write!(
+            result,
+            "<a href=\"{link_target}\" \
+             class=\"obsidian-link\">{escaped_page}</a>"
+          );
+        }
+      } else {
+        result.push_str("[[");
+        result.push_str(&inner);
+      }
+    } else {
+      result.push(ch);
+    }
+  }
+
+  result
+}
+
 #[cfg(test)]
 mod tests {
   use super::*;
@@ -1354,5 +1451,67 @@ mod tests {
 
     // edge case: 7 hashes (invalid)
     assert!(!is_atx_header("####### Not valid"));
+  }
+
+  #[cfg(feature = "wiki")]
+  #[test]
+  fn test_wikilink_obsidian_basic() {
+    let input = "Check out [[Some Page]] for details.";
+    let result = process_wikilinks(input);
+    assert!(result.contains("href=\"Some Page.html\""));
+    assert!(result.contains("class=\"obsidian-link\""));
+    assert!(result.contains(">Some Page<"));
+  }
+
+  #[cfg(feature = "wiki")]
+  #[test]
+  fn test_wikilink_with_url() {
+    let input = "See [[Custom Name|https://example.com]]";
+    let result = process_wikilinks(input);
+    assert!(result.contains("href=\"https://example.com\""));
+    assert!(result.contains("class=\"wikilink\""));
+    assert!(result.contains(">Custom Name<"));
+  }
+
+  #[cfg(feature = "wiki")]
+  #[test]
+  fn test_wikilink_with_spaces() {
+    let input = "[[My Page Name]]";
+    let result = process_wikilinks(input);
+    assert!(result.contains("href=\"My Page Name.html\""));
+  }
+
+  #[cfg(feature = "wiki")]
+  #[test]
+  fn test_wikilink_in_code_block() {
+    let input = "```\n[[Wiki Link]]\n```\nThen [[Another]]";
+    let result = process_wikilinks(input);
+    assert!(result.contains("[[Wiki Link]]"));
+    assert!(result.contains("href=\"Another.html\""));
+  }
+
+  #[cfg(feature = "wiki")]
+  #[test]
+  fn test_wikilink_empty() {
+    let input = "[[]]";
+    let result = process_wikilinks(input);
+    assert!(result.contains("[[]]"));
+  }
+
+  #[cfg(feature = "wiki")]
+  #[test]
+  fn test_wikilink_malformed() {
+    let input = "[[ incomplete";
+    let result = process_wikilinks(input);
+    assert!(result.contains("[[ incomplete"));
+  }
+
+  #[cfg(feature = "wiki")]
+  #[test]
+  fn test_wikilink_html_escaping() {
+    let input = "See [[Page With <script>]] for info";
+    let result = process_wikilinks(input);
+    assert!(result.contains("&lt;script&gt;"));
+    assert!(!result.contains(">Page With <script><"));
   }
 }

--- a/ndg-commonmark/src/processor/mod.rs
+++ b/ndg-commonmark/src/processor/mod.rs
@@ -33,6 +33,8 @@ pub use extensions::process_myst_autolinks;
 pub use extensions::process_option_references;
 #[cfg(any(feature = "nixpkgs", feature = "ndg-flavored"))]
 pub use extensions::process_role_markup;
+#[cfg(feature = "wiki")]
+pub use extensions::process_wikilinks;
 #[cfg(feature = "nixpkgs")]
 pub use extensions::{
   process_block_elements,

--- a/ndg/docs/FRONTMATTER.md
+++ b/ndg/docs/FRONTMATTER.md
@@ -106,6 +106,18 @@ toc = false
 
 Defaults to `true` (TOC is generated whenever headings are present).
 
+### `tags`
+
+Per-page tags, as a list of strings. Injected as `<meta name="keywords">` and
+take precedence over the global `meta.tags.keywords` configuration for this page
+only.
+
+```toml
++++
+tags = ["nix", "configuration", "modules"]
++++
+```
+
 ### `extra`
 
 Arbitrary user-defined data, as a TOML table. The entire table is serialised and
@@ -145,6 +157,7 @@ regardless of whether they affect rendering automatically:
 | `{{ page.author }}`      | `String\|null`  | Frontmatter author, if set        |
 | `{{ page.template }}`    | `String\|null`  | Frontmatter template name, if set |
 | `{{ page.toc }}`         | `Boolean\|null` | Frontmatter toc setting, if set   |
+| `{{ page.tags }}`        | `Array\|null`   | Frontmatter tags, if set          |
 | `{{ page.extra }}`       | `Object\|null`  | Frontmatter extra table, if set   |
 
 <!--markdownlint-enable MD013-->
@@ -172,6 +185,7 @@ the affected page only. All other pages remain unaffected.
 | ----------------- | --------------------------------------- |
 | `description`     | `meta.tags.description`                 |
 | `author`          | `meta.tags.author`                      |
+| `tags`            | `meta.tags.keywords`                    |
 | `title`           | First H1 heading                        |
 | `template`        | File-stem template, then `default.html` |
 | `toc`             | Default TOC generation                  |


### PR DESCRIPTION
I'm introducing two main features: support for per-page `tags` in Markdown frontmatter, and wiki/Obsidian-style double-bracket link parsing mostly because I think they're neat additions to a wiki-style documentation site.

The `tags` feature allows authors to specify page-specific keywords that override global site settings, while the wiki link parsing adds a feature-flagged extension for converting `[[page]]` and `[[name|url]]` links into appropriate HTML anchors.

I think these are nice little improvements to site customization and content authoring, especially for users that are familiar with Obsidian workflows.