### PR TITLE
ndg: `--dest-dir` alias for `--output-dir` and `--open` to open docs automatically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,9 @@ changes.
   - `index.generate_fallback` (default: `true`): Controls whether NDG creates a
     fallback index page listing all documentation when no index file is
     provided.
+- `--dest-dir` alias for `--output-dir` in `ndg html` command.
+- `--open` flag for `ndg html` to open the generated documentation in the
+  default browser after generation completes.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,12 @@ changes.
     fallback index page listing all documentation when no index file is
     provided.
 
+### Changed
+
+- `ndg-builder` now takes a **list** of stylesheets instead of a single one as
+  `--stylesheet` is now additive and can be specified multiple times. When a
+  _string_ is provided, `ndg-builder` will be an evaluation failure.
+
 ### Fixed
 
 - Markdown links to `.md` files (e.g. `[foo](./bar.md)`) are now correctly

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1502,6 +1502,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-docker"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "928bae27f42bc99b60d9ac7334e3a21d10ad8f1835a4e12ec3ec0464765ed1b3"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "is-wsl"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "173609498df190136aa7dea1a91db051746d339e18476eed5ca40521f02d7aa5"
+dependencies = [
+ "is-docker",
+ "once_cell",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1857,6 +1876,7 @@ dependencies = [
  "ndg-nixdoc",
  "ndg-utils",
  "num_cpus",
+ "open",
  "rayon",
  "regex",
  "serde",
@@ -2116,6 +2136,17 @@ name = "oorandom"
 version = "11.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
+name = "open"
+version = "5.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f3bab717c29a857abf75fcef718d441ec7cb2725f937343c734740a985d37fd"
+dependencies = [
+ "is-wsl",
+ "libc",
+ "pathdiff",
+]
 
 [[package]]
 name = "outref"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ indicatif = { version = "0.18.4", features = [ "rayon" ] }
 jiff = "0.2.24"
 log = "0.4.29"
 num_cpus = "1.17.0"
+open = "5.3.4"
 rand = "0.10.1"
 
 comrak = { version = "0.52.0", default-features = false, features = [ "syntect" ] }

--- a/ndg/Cargo.toml
+++ b/ndg/Cargo.toml
@@ -23,6 +23,8 @@ ndg-manpage.workspace    = true
 ndg-nixdoc.workspace     = true
 ndg-utils.workspace      = true
 
+open.workspace           = true
+
 clap.workspace                = true
 clap-verbosity-flag.workspace = true
 color-eyre.workspace          = true

--- a/ndg/src/cli.rs
+++ b/ndg/src/cli.rs
@@ -69,7 +69,7 @@ pub enum Commands {
     input_dir: Option<PathBuf>,
 
     /// Output directory for generated documentation.
-    #[arg(short, long)]
+    #[arg(short, long, alias = "dest-dir")]
     output_dir: Option<PathBuf>,
 
     /// Number of threads to use for parallel processing.
@@ -136,6 +136,10 @@ pub enum Commands {
     #[cfg(feature = "serve")]
     #[arg(long = "serve-port", default_value = "3000")]
     serve_port: u16,
+
+    /// Open the generated documentation in the default browser.
+    #[arg(long = "open", action = clap::ArgAction::SetTrue)]
+    open: bool,
   },
 
   /// Generate manpage from options.

--- a/ndg/src/main.rs
+++ b/ndg/src/main.rs
@@ -123,16 +123,16 @@ fn main() -> Result<()> {
   }
 
   // Run the main documentation generation process
-  #[cfg(feature = "serve")]
-  let output_dir = config.output_dir.clone();
   generate_documentation(&mut config)?;
 
-  // Check if we should serve the documentation
+  // Handle --open flag if present
+  handle_open_flag(&cli.command, &config.output_dir);
+
+  // Handle --serve if enabled
   #[cfg(feature = "serve")]
   {
-    let should_serve =
-      matches!(&cli.command, Some(Commands::Html { serve: true, .. }));
-    if should_serve {
+    let output_dir = config.output_dir.clone();
+    if matches!(&cli.command, Some(Commands::Html { serve: true, .. })) {
       let serve_port =
         if let Some(Commands::Html { serve_port, .. }) = &cli.command {
           *serve_port
@@ -145,6 +145,18 @@ fn main() -> Result<()> {
   }
 
   Ok(())
+}
+
+/// Handle the --open flag to open the generated documentation in browser.
+fn handle_open_flag(command: &Option<Commands>, output_dir: &Path) {
+  let should_open = matches!(command, Some(Commands::Html { open: true, .. }));
+  if should_open {
+    let index_path = output_dir.join("index.html");
+    info!("Opening {} in browser", index_path.display());
+    if let Err(e) = open::that(&index_path) {
+      log::error!("Failed to open browser: {e}");
+    }
+  }
 }
 
 /// Merge CLI command options into the configuration
@@ -170,6 +182,7 @@ fn merge_cli_into_config(config: &mut Config, cli: &Cli) {
       serve: _,
     #[cfg(feature = "serve")]
       serve_port: _,
+    open: _,
   }) = &cli.command
   {
     if let Some(input_dir) = input_dir {

--- a/nix/packages/ndg-builder/package.nix
+++ b/nix/packages/ndg-builder/package.nix
@@ -5,6 +5,7 @@
   ndg,
   runCommandLocal,
   nixosOptionsDoc,
+  writers,
   # Options
   checkModules ? false,
   rawModules ? [
@@ -97,21 +98,24 @@
   title ? "Site created by NDG",
   description ? "Generate static site docs of nix options",
   optionsDocArgs ? {},
-  scripts ? [],
   inputDir ? null,
-  stylesheet ? null,
+  stylesheets ? [],
+  scripts ? [],
   verbose ? true,
   manpageUrls ? null,
   optionsDepth ? 2,
   generateSearch ? true,
   highlightCode ? true,
 } @ args: let
+  inherit (builtins) typeOf;
+  inherit (lib.modules) mkIf;
   inherit (lib.asserts) assertMsg;
 in
   # TODO explain this one
   assert args ? specialArgs -> args ? rawModules;
+  assert assertMsg (typeOf stylesheets "list") "The stylesheets option is now additive, and takes a list instead";
   assert assertMsg (args ? evaluatedModules -> !(args ? rawModules)) "evaluatedModules and rawModules are mutually exclusive"; let
-    inherit (lib.strings) optionalString concatMapStringsSep;
+    inherit (lib.strings) optionalString;
 
     configJSON =
       (nixosOptionsDoc (
@@ -120,35 +124,27 @@ in
         // {inherit (evaluatedModules) options;}
       ))
       .optionsJSON;
+
+    ndgConfig = writers.writeToml "ndg.toml" {
+      # Core Options
+      inherit title;
+      output_dir = builtins.placeholder "out";
+      input_dir = mkIf (inputDir != null) (toString inputDir);
+      module_options = mkIf (inputDir != null) "\"${configJSON}/share/doc/nixos/options.json\""; # TODO: check if there are options
+      search.enable = generateSearch;
+      highlight_code = highlightCode;
+      sidebar.options.depth = optionsDepth;
+      manpage_urls_path = mkIf (manpageUrls != null) manpageUrls;
+      stylesheet_paths = mkIf (stylesheets != []) stylesheets;
+      script_paths = mkIf (stylesheets != []) scripts;
+    };
   in
     runCommandLocal "ndg-builder" {
       nativeBuildInputs = [ndg];
       meta = {inherit description;};
     } (
+      optionalString (inputDir == null) ''
+        ndg --config-file "${ndgConfig}" ${optionalString verbose "--verbose"} html \
+          --jobs $NIX_BUILD_CORES --output-dir "$out"
       ''
-        mkdir -p $out
-        config_path="$TMPDIR/ndg-builder.toml"
-        {
-          echo "output_dir = \"$out\""
-      ''
-      + optionalString (inputDir != null) ''
-        echo "input_dir = \"${toString inputDir}\""
-      ''
-      + optionalString (inputDir == null) ''
-        echo "module_options = \"${configJSON}/share/doc/nixos/options.json\""
-      ''
-      + ''
-        } > "$config_path"
-
-        ndg --config-file "$config_path" ${optionalString verbose "--verbose"} html \
-          --jobs $NIX_BUILD_CORES --output-dir "$out" --title "${title}" \
-          --module-options "${configJSON}/share/doc/nixos/options.json" \
-      ''
-      + optionalString (scripts != []) ''${concatMapStringsSep "-" (x: "--script ${x}") scripts} \''
-      + optionalString (stylesheet != null) ''--stylesheet ${toString stylesheet} \''
-      + optionalString (inputDir != null) ''--input-dir ${inputDir} \''
-      + optionalString (manpageUrls != null) ''--manpage-urls ${manpageUrls} \''
-      + optionalString generateSearch ''--generate-search \''
-      + optionalString highlightCode ''--highlight-code \''
-      + "--options-depth ${toString optionsDepth}"
     )


### PR DESCRIPTION
Adds a flag to `ndg html` command to open documentation in the browser (crossplatform!) to make it easier for users to specify output directories and quickly view generated documentation. I've also added a `--dest-dir` alias to `--output-dir` to provide a bit of consistency with MdBook for users that are familiar with it.
