### PR TITLE
ndg-builder: fix config generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,13 +83,6 @@ documentation using the old hyphen-based format will need to be updated**.
 
 ### Added
 
-- New `[index]` configuration section for controlling homepage generation.
-  - `index.use_readme` (default: `false`): When enabled, `README.md` is rendered
-    as `index.html` (the site homepage) instead of `README.html` when no
-    `index.md` is present.
-  - `index.generate_fallback` (default: `true`): Controls whether NDG creates a
-    fallback index page listing all documentation when no index file is
-    provided.
 - Optional `meta.favicon` option to specify one or more favicon entries. Each
   entry produces a `<link>` tag in the HTML head and its file is copied to the
   root of the output directory. Supports arbitrary `rel`, `type`, `sizes`, and

--- a/nix/packages/ndg-builder/package.nix
+++ b/nix/packages/ndg-builder/package.nix
@@ -137,7 +137,7 @@ in
         sidebar.options.depth = optionsDepth;
       }
       // optionalAttrs (inputDir != null) {
-        input_dir = "\"${toString inputDir}\"";
+        input_dir = inputDir;
         module_options = "\"${configJSON}/share/doc/nixos/options.json\""; # TODO: check if there are options
       }
       // optionalAttrs (manpageUrls != null) { manpage_urls_path = manpageUrls; }

--- a/nix/packages/ndg-builder/package.nix
+++ b/nix/packages/ndg-builder/package.nix
@@ -109,7 +109,7 @@
   extraConfig ? {},
 } @ args: let
   inherit (builtins) isList;
-  inherit (lib.modules) mkIf;
+  inherit (lib.modules) mkMerge;
   inherit (lib.attrsets) optionalAttrs;
   inherit (lib.asserts) assertMsg;
 in
@@ -128,23 +128,24 @@ in
       .optionsJSON;
 
     ndgConfig =
-      writers.writeTOML "ndg.toml" ({
-        # Core Options
-        inherit title;
-        output_dir = builtins.placeholder "out";
-        search.enable = generateSearch;
-        highlight_code = highlightCode;
-        sidebar.options.depth = optionsDepth;
-      }
-      // optionalAttrs (inputDir != null) {
-        input_dir = inputDir;
-        module_options = "${configJSON}/share/doc/nixos/options.json"; # TODO: check if there are options
-      }
-      // optionalAttrs (manpageUrls != null) { manpage_urls_path = manpageUrls; }
-      // optionalAttrs (stylesheets != []) { stylesheet_paths = stylesheets; }
-      // optionalAttrs (scripts != []) { script_paths = scripts; }
-      // optionalAttrs (extraConfig != {}) extraConfig
-      );
+      writers.writeTOML "ndg.toml" (mkMerge [
+        {
+          # Core Options
+          inherit title;
+          output_dir = placeholder "out";
+          search.enable = generateSearch;
+          highlight_code = highlightCode;
+          sidebar.options.depth = optionsDepth;
+        }
+        (optionalAttrs (inputDir != null) {
+          input_dir = inputDir;
+          module_options = "${configJSON}/share/doc/nixos/options.json"; # TODO: check if there are options
+        })
+        (optionalAttrs (manpageUrls != null) { manpage_urls_path = manpageUrls; })
+        (optionalAttrs (stylesheets != []) { stylesheet_paths = stylesheets; })
+        (optionalAttrs (scripts != []) { script_paths = scripts; })
+        (optionalAttrs (extraConfig != {}) extraConfig)
+      ]);
   in
     runCommandLocal "ndg-builder" {
       nativeBuildInputs = [ndg];

--- a/nix/packages/ndg-builder/package.nix
+++ b/nix/packages/ndg-builder/package.nix
@@ -128,7 +128,7 @@ in
       .optionsJSON;
 
     ndgConfig =
-      writers.writeToml "ndg.toml" {
+      writers.writeTOML "ndg.toml" {
         # Core Options
         inherit title;
         output_dir = builtins.placeholder "out";

--- a/nix/packages/ndg-builder/package.nix
+++ b/nix/packages/ndg-builder/package.nix
@@ -128,27 +128,28 @@ in
       .optionsJSON;
 
     ndgConfig =
-      writers.writeTOML "ndg.toml" {
+      writers.writeTOML "ndg.toml" ({
         # Core Options
         inherit title;
         output_dir = builtins.placeholder "out";
-        input_dir = mkIf (inputDir != null) (toString inputDir);
-        module_options = mkIf (inputDir != null) "\"${configJSON}/share/doc/nixos/options.json\""; # TODO: check if there are options
         search.enable = generateSearch;
         highlight_code = highlightCode;
         sidebar.options.depth = optionsDepth;
-        manpage_urls_path = mkIf (manpageUrls != null) manpageUrls;
-        stylesheet_paths = mkIf (stylesheets != []) stylesheets;
-        script_paths = mkIf (scripts != []) scripts;
       }
-      // optionalAttrs (extraConfig != {}) extraConfig;
+      // optionalAttrs (inputDir != null) {
+        input_dir = "\"${toString inputDir}\"";
+        module_options = "\"${configJSON}/share/doc/nixos/options.json\""; # TODO: check if there are options
+      }
+      // optionalAttrs (manpageUrls != null) { manpage_urls_path = manpageUrls; }
+      // optionalAttrs (stylesheets != []) { stylesheet_paths = stylesheets; }
+      // optionalAttrs (scripts != []) { script_paths = scripts; }
+      // optionalAttrs (extraConfig != {}) extraConfig
+      );
   in
     runCommandLocal "ndg-builder" {
       nativeBuildInputs = [ndg];
       meta = {inherit description;};
-    } (
-      optionalString (inputDir == null) ''
+    } ''
         ndg --config-file "${ndgConfig}" ${optionalString verbose "--verbose"} html \
           --jobs $NIX_BUILD_CORES --output-dir "$out"
       ''
-    )

--- a/nix/packages/ndg-builder/package.nix
+++ b/nix/packages/ndg-builder/package.nix
@@ -136,11 +136,9 @@ in
           search.enable = generateSearch;
           highlight_code = highlightCode;
           sidebar.options.depth = optionsDepth;
-        }
-        (optionalAttrs (inputDir != null) {
-          input_dir = inputDir;
           module_options = "${configJSON}/share/doc/nixos/options.json"; # TODO: check if there are options
-        })
+        }
+        (optionalAttrs (inputDir != null) { input_dir = inputDir; })
         (optionalAttrs (manpageUrls != null) { manpage_urls_path = manpageUrls; })
         (optionalAttrs (stylesheets != []) { stylesheet_paths = stylesheets; })
         (optionalAttrs (scripts != []) { script_paths = scripts; })

--- a/nix/packages/ndg-builder/package.nix
+++ b/nix/packages/ndg-builder/package.nix
@@ -138,7 +138,7 @@ in
       }
       // optionalAttrs (inputDir != null) {
         input_dir = inputDir;
-        module_options = "\"${configJSON}/share/doc/nixos/options.json\""; # TODO: check if there are options
+        module_options = "${configJSON}/share/doc/nixos/options.json"; # TODO: check if there are options
       }
       // optionalAttrs (manpageUrls != null) { manpage_urls_path = manpageUrls; }
       // optionalAttrs (stylesheets != []) { stylesheet_paths = stylesheets; }


### PR DESCRIPTION
ndg-builder was broken in the way it tried generate the config 
- `write.writeToml` doesn't exist, it's `writers.writeTOML`
- the builder allowed for null values to enter the writer, which writeTOML doesn't like, so then it fails to build
- for some reason if inputDir WAS NOT null, it skipped the building process and then failed to generate outpath
- module_options added escaped quotes to the toml which broke it because then ndg couldn't access the path (i looked at generated toml file and it was `module_options = "\"blahblah\""` which is very silly

also fixed a mistake in the changelog


sorry about all the force pushing lol, i have a bad habit