### PR TITLE
ndg-commonmark: align TOC anchors with heading ids for escaped markup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,7 @@ changes.
 - Generated pages now remain readable with JavaScript disabled. JS-only controls
   are hidden, sidebar navigation stays in document flow, fixed page TOCs are
   disabled without scripts, and mobile overflow handling has been improved.
+- TOC anchors now match heading IDs even if the headings contained HTML entities.
 
 ## [2.8.2]
 

--- a/crates/ndg-html/tests/hierarchical_search.rs
+++ b/crates/ndg-html/tests/hierarchical_search.rs
@@ -551,8 +551,8 @@ fn test_anchor_id_generation() {
     .iter()
     .find(|a| a["text"].as_str().unwrap() == "Installation & Setup")
     .expect("Should have 'Installation & Setup' anchor");
-  // Ampersand and spaces are converted: " & " becomes "---"
-  assert_eq!(installation["id"].as_str().unwrap(), "installation---setup");
+  // Ampersand and spaces are converted: " & " becomes "--amp--"
+  assert_eq!(installation["id"].as_str().unwrap(), "installation--amp--setup");
 
   // Find "User's Guide" anchor
   let users_guide = anchors

--- a/ndg-commonmark/src/processor/core.rs
+++ b/ndg-commonmark/src/processor/core.rs
@@ -484,16 +484,10 @@ impl MarkdownProcessor {
             let anchor = &trimmed[start + 2..start + end];
             (trimmed[..start].trim_end().to_string(), anchor.to_string())
           } else {
-            (
-              text.clone(),
-              explicit_id.unwrap_or_else(|| utils::slugify(&text)),
-            )
+            (text.clone(), explicit_id.unwrap_or_else(|| slugify_heading(&text)))
           }
         } else {
-          (
-            text.clone(),
-            explicit_id.unwrap_or_else(|| utils::slugify(&text)),
-          )
+          (text.clone(), explicit_id.unwrap_or_else(|| slugify_heading(&text)))
         };
         if *level == 1 && found_title.is_none() {
           found_title = Some(final_text.clone());
@@ -1182,6 +1176,24 @@ pub fn extract_inline_text<'a>(node: &'a AstNode<'a>) -> String {
     text
   }
   inner(node)
+}
+
+/// Slugify heading text for use as a table-of-contents anchor.
+///
+/// The auto-generated heading `id` is produced by slugifying the *rendered*
+/// HTML (see `process_header_anchors_html`), in which comrak has escaped any
+/// markup characters: an option heading like `environments.<name>.deployment`
+/// becomes `environments.&lt;name&gt;.deployment` before slugifying. The
+/// table-of-contents, by contrast, slugifies the raw inline text (`<name>`),
+/// which would yield a different slug and break "jump to header" for every
+/// heading containing such characters.
+///
+/// To keep both in sync, escape the text the same way comrak does before
+/// slugifying, so the TOC href matches the on-page heading `id`. The heading
+/// `id` itself is intentionally left unchanged to preserve existing deep links.
+#[must_use]
+pub(crate) fn slugify_heading(text: &str) -> String {
+  utils::slugify(&html_escape::encode_text(text))
 }
 
 /// Collect all markdown files from the input directory

--- a/ndg-commonmark/src/processor/mod.rs
+++ b/ndg-commonmark/src/processor/mod.rs
@@ -103,6 +103,36 @@ mod tests {
   }
 
   #[test]
+  fn test_toc_anchor_matches_heading_id_for_angle_brackets() {
+    // Regression: a heading whose text contains markup characters such as
+    // `<name>` must have its table-of-contents anchor (`Header.id`) match the
+    // auto-generated `id` attribute on the rendered heading, otherwise
+    // "jump to header" links point at a non-existent anchor. The heading `id`
+    // slugifies the escaped HTML (`&lt;name&gt;`), so the TOC must too.
+    let processor = MarkdownProcessor::new(MarkdownOptions::default());
+    // The Nix options renderer emits the angle brackets backslash-escaped so
+    // comrak treats them as literal text rather than an inline HTML tag,
+    // yielding `environments.&lt;name&gt;.deployment` in the rendered heading.
+    let result = processor.render("## environments.\\<name\\>.deployment\n");
+
+    let header = result
+      .headers
+      .iter()
+      .find(|h| h.level == 2)
+      .expect("expected an h2 header");
+
+    // The heading id is the slug of the escaped HTML, not the raw `<name>`.
+    assert_eq!(header.id, "environments--lt-name-gt--deployment");
+    // The rendered HTML must carry the same id so the TOC anchor resolves.
+    assert!(
+      result.html.contains(&format!("id=\"{}\"", header.id)),
+      "rendered HTML {:?} is missing id={:?}",
+      result.html,
+      header.id
+    );
+  }
+
+  #[test]
   fn test_various_role_types_with_html_characters() {
     #[cfg(any(feature = "nixpkgs", feature = "ndg-flavored"))]
     {


### PR DESCRIPTION
Encodes HTML entities in heading ids in the TOC anchors to unbreak jump-to-header for headers with auto ids based on HTML entities in their content (e.g. `.<name>`).

This solution intentionally preserves the current (uglier) auto-ids (rather than resolving the gap the other way around) to prevent existing deep-links from breaking.

Closes #217.

Disclaimer: I used a coding agent in the creation of this patch.
