### PR TITLE
Markdown processing perf with caching and parallel rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,9 @@ changes.
 
 ### Changed
 
+- HTML generation now processes Markdown pages in parallel and caches rendered
+  results in `.ndg-cache/markdown` for faster repeated builds; `ndg init`
+  ignores this generated cache automatically.
 - Mobile documentation navigation now uses a header menu button and modal
   sidebar with backdrop, close button, Escape handling, and cloned site
   navigation instead of the previous floating action button and draggable bottom

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -201,6 +201,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayref"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
+
+[[package]]
 name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -389,6 +395,20 @@ dependencies = [
  "radium",
  "tap",
  "wyz",
+]
+
+[[package]]
+name = "blake3"
+version = "1.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0aa83c34e62843d924f905e0f5c866eb1dd6545fc4d719e803d9ba6030371fce"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "cc",
+ "cfg-if",
+ "constant_time_eq",
+ "cpufeatures",
 ]
 
 [[package]]
@@ -786,6 +806,12 @@ dependencies = [
  "quote",
  "syn 1.0.109",
 ]
+
+[[package]]
+name = "constant_time_eq"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 
 [[package]]
 name = "convert_case"
@@ -2373,6 +2399,7 @@ dependencies = [
 name = "ndg-utils"
 version = "2.9.0"
 dependencies = [
+ "blake3",
  "color-eyre",
  "fs_extra",
  "grass",
@@ -2394,6 +2421,7 @@ dependencies = [
  "rustc-hash 2.1.2",
  "serde",
  "serde_json",
+ "tempfile",
  "toml 1.1.2+spec-1.1.0",
  "walkdir",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,6 +91,7 @@ quote       = "1.0.46"
 syn         = { version = "3.0.3", features = ["full", "derive"] }
 
 criterion = { version = "0.8.2", features = [ "html_reports" ], default-features = false }
+blake3 = "1.8.3"
 tempfile  = "3.27.0"
 
 # See:

--- a/crates/ndg-utils/Cargo.toml
+++ b/crates/ndg-utils/Cargo.toml
@@ -25,6 +25,7 @@ ndg-config.workspace     = true
 ndg-templates.workspace  = true
 
 color-eyre.workspace    = true
+blake3.workspace        = true
 fs_extra.workspace      = true
 grass.workspace         = true
 html-escape.workspace   = true
@@ -44,3 +45,6 @@ serde.workspace         = true
 serde_json.workspace    = true
 toml.workspace          = true
 walkdir.workspace       = true
+
+[dev-dependencies]
+tempfile.workspace = true

--- a/crates/ndg-utils/src/lib.rs
+++ b/crates/ndg-utils/src/lib.rs
@@ -8,7 +8,11 @@ pub mod xref;
 
 // Re-export commonly used utilities
 pub use assets::copy_assets;
-pub use markdown::{create_processor, process_markdown_files};
+pub use markdown::{
+  create_processor,
+  process_markdown_files,
+  process_markdown_files_with_cache,
+};
 pub use output::create_fallback_index;
 pub use xref::{
   AnchorEntry,

--- a/crates/ndg-utils/src/markdown.rs
+++ b/crates/ndg-utils/src/markdown.rs
@@ -1,6 +1,7 @@
 use std::{
   fs,
   path::{Path, PathBuf},
+  sync::Mutex,
 };
 
 use color_eyre::eyre::{Context, Result};
@@ -125,6 +126,18 @@ struct MarkdownCacheEntry {
   frontmatter:      Option<PageFrontmatter>,
 }
 
+#[derive(Serialize)]
+struct MarkdownCacheEntryRef<'a> {
+  schema:           u8,
+  source_digest:    &'a str,
+  dependencies:     Vec<(PathBuf, Option<String>)>,
+  processor_digest: &'a str,
+  result:           &'a ndg_commonmark::MarkdownResult,
+  frontmatter:      Option<&'a PageFrontmatter>,
+}
+
+type DependencyDigests = Mutex<FxHashMap<PathBuf, Option<String>>>;
+
 /// Processes all markdown files in the input directory and returns processed
 /// data.
 ///
@@ -212,16 +225,8 @@ fn process_markdown_files_impl(
     let base_processor = processor
       .map_or_else(|| create_processor(config, None), std::clone::Clone::clone);
 
-    // Store render results to avoid rendering twice
-    #[expect(clippy::items_after_statements, reason = "Local type alias")]
-    type RenderCache = FxHashMap<PathBuf, ndg_commonmark::MarkdownResult>;
-    let mut render_cache: RenderCache = FxHashMap::default();
-
-    // Store parsed frontmatter per source file
-    let mut frontmatter_cache: FxHashMap<PathBuf, Option<PageFrontmatter>> =
-      FxHashMap::default();
-
     let cache = cache_dir.map(|dir| (dir, processor_digest(&base_processor)));
+    let dependency_digests = DependencyDigests::default();
     let progress = ProgressBar::new(files.len() as u64);
     #[expect(
       clippy::expect_used,
@@ -255,9 +260,10 @@ fn process_markdown_files_impl(
             base_dir,
             &source_digest,
             processor_digest,
+            &dependency_digests,
           )
         {
-          return Ok((file_path.clone(), entry.frontmatter, entry.result));
+          return Ok((entry.frontmatter, entry.result));
         }
 
         let (frontmatter, content) = strip_frontmatter(&raw_content);
@@ -276,13 +282,13 @@ fn process_markdown_files_impl(
             frontmatter.as_ref(),
           );
         }
-        Ok((file_path.clone(), frontmatter, result))
+        Ok((frontmatter, result))
       })
       .collect();
     progress.finish_with_message("Markdown processing complete");
 
-    for (file_path, frontmatter, result) in rendered? {
-      frontmatter_cache.insert(file_path.clone(), frontmatter);
+    let rendered = rendered?;
+    for (file_path, (_, result)) in files.iter().zip(&rendered) {
       let base_dir = file_path.parent().unwrap_or(input_dir.as_path());
 
       // Track custom outputs for included files
@@ -320,19 +326,10 @@ fn process_markdown_files_impl(
             .or_insert_with(|| includer_rel.to_owned());
         }
       }
-
-      // Cache the render result
-      render_cache.insert(file_path, result);
     }
 
-    // Second pass: use cached results to build output map
-    for file_path in &files {
-      // Retrieve cached result instead of rendering again
-      #[expect(clippy::expect_used, reason = "File is guaranteed to be cached")]
-      let result = render_cache
-        .get(file_path)
-        .expect("File should have cached result");
-
+    // Second pass: build output entries after resolving include relationships.
+    for (file_path, (frontmatter, result)) in files.into_iter().zip(rendered) {
       let rel_path = file_path.strip_prefix(input_dir).wrap_err_with(|| {
         format!(
           "Failed to determine relative path for {}",
@@ -364,18 +361,16 @@ fn process_markdown_files_impl(
       let custom_outputs =
         pending_custom_outputs.remove(rel_path).unwrap_or_default();
 
-      let frontmatter = frontmatter_cache.remove(file_path).flatten();
-
       // If this file has custom outputs via html:into-file, write to those
       // locations
       if custom_outputs.is_empty() {
         output_map.insert(
           output_path_str,
           (
-            result.html.clone(),
-            result.headers.clone(),
-            result.title.clone(),
-            file_path.clone(),
+            result.html,
+            result.headers,
+            result.title,
+            file_path,
             is_included,
             frontmatter,
           ),
@@ -504,6 +499,7 @@ fn read_cache(
   base_dir: &Path,
   source_digest: &str,
   processor_digest: &str,
+  dependency_digests: &DependencyDigests,
 ) -> Option<MarkdownCacheEntry> {
   let entry: MarkdownCacheEntry =
     serde_json::from_slice(&fs::read(cache_path(cache_dir, source)).ok()?)
@@ -517,8 +513,30 @@ fn read_cache(
   entry
     .dependencies
     .iter()
-    .all(|(path, expected)| digest_file(&base_dir.join(path)) == *expected)
+    .all(|(path, expected)| {
+      dependency_matches(
+        &base_dir.join(path),
+        expected.as_deref(),
+        dependency_digests,
+      )
+    })
     .then_some(entry)
+}
+
+fn dependency_matches(
+  path: &Path,
+  expected: Option<&str>,
+  digests: &DependencyDigests,
+) -> bool {
+  // ponytail: first reads are serialized; shard if unique includes dominate.
+  let Ok(mut digests) = digests.lock() else {
+    return false;
+  };
+  digests
+    .entry(path.to_owned())
+    .or_insert_with(|| digest_file(path))
+    .as_deref()
+    == expected
 }
 
 fn write_cache(
@@ -539,13 +557,13 @@ fn write_cache(
       (path, digest)
     })
     .collect();
-  let entry = MarkdownCacheEntry {
+  let entry = MarkdownCacheEntryRef {
     schema: MARKDOWN_CACHE_SCHEMA,
-    source_digest: source_digest.to_owned(),
+    source_digest,
     dependencies,
-    processor_digest: processor_digest.to_owned(),
-    result: result.clone(),
-    frontmatter: frontmatter.cloned(),
+    processor_digest,
+    result,
+    frontmatter,
   };
   let Ok(data) = serde_json::to_vec(&entry) else {
     return;
@@ -652,6 +670,23 @@ mod tests {
   use tempfile::TempDir;
 
   use super::*;
+
+  fn read_cache(
+    cache_dir: &Path,
+    source: &Path,
+    base_dir: &Path,
+    source_digest: &str,
+    processor_digest: &str,
+  ) -> Option<MarkdownCacheEntry> {
+    super::read_cache(
+      cache_dir,
+      source,
+      base_dir,
+      source_digest,
+      processor_digest,
+      &DependencyDigests::default(),
+    )
+  }
 
   #[test]
   fn cache_rejects_changed_inputs() {

--- a/crates/ndg-utils/src/markdown.rs
+++ b/crates/ndg-utils/src/markdown.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use color_eyre::eyre::{Context, Result};
-use indicatif::{ProgressBar, ProgressStyle};
+use indicatif::{ParallelProgressIterator, ProgressBar, ProgressStyle};
 use log::{info, warn};
 use ndg_commonmark::{
   Header,
@@ -14,8 +14,9 @@ use ndg_commonmark::{
   processor::types::TabStyle,
 };
 use ndg_config::Config;
+use rayon::prelude::*;
 use rustc_hash::{FxHashMap, FxHashSet};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 /// TOML frontmatter parsed from the `+++` delimited block at the start of a
 /// markdown document.
@@ -23,7 +24,7 @@ use serde::Deserialize;
 /// Frontmatter must appear at the very beginning of the file, wrapped in
 /// `+++` delimiters on their own lines. Any unrecognised keys are silently
 /// ignored by the TOML deserialiser.
-#[derive(Debug, Default, Clone, Deserialize)]
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
 pub struct PageFrontmatter {
   /// Overrides the page title extracted from the first H1 heading.
   pub title:       Option<String>,
@@ -112,6 +113,18 @@ pub struct ProcessedMarkdown {
   pub frontmatter:  Option<PageFrontmatter>,
 }
 
+const MARKDOWN_CACHE_SCHEMA: u8 = 2;
+
+#[derive(Serialize, Deserialize)]
+struct MarkdownCacheEntry {
+  schema:           u8,
+  source_digest:    String,
+  dependencies:     Vec<(PathBuf, Option<String>)>,
+  processor_digest: String,
+  result:           ndg_commonmark::MarkdownResult,
+  frontmatter:      Option<PageFrontmatter>,
+}
+
 /// Processes all markdown files in the input directory and returns processed
 /// data.
 ///
@@ -143,9 +156,32 @@ pub fn process_markdown_files(
   config: &mut Config,
   processor: Option<&MarkdownProcessor>,
 ) -> Result<Vec<ProcessedMarkdown>> {
+  process_markdown_files_impl(config, processor, None)
+}
+
+/// Processes markdown files, reusing project-local render entries when valid.
+///
+/// # Errors
+///
+/// Returns an error when Markdown sources cannot be collected, read, or
+/// processed.
+pub fn process_markdown_files_with_cache(
+  config: &mut Config,
+  processor: Option<&MarkdownProcessor>,
+  cache_dir: &Path,
+) -> Result<Vec<ProcessedMarkdown>> {
+  process_markdown_files_impl(config, processor, Some(cache_dir))
+}
+
+fn process_markdown_files_impl(
+  config: &mut Config,
+  processor: Option<&MarkdownProcessor>,
+  cache_dir: Option<&Path>,
+) -> Result<Vec<ProcessedMarkdown>> {
   if let Some(ref input_dir) = config.input_dir {
     info!("Input directory: {}", input_dir.display());
-    let files = collect_markdown_files(input_dir);
+    let mut files = collect_markdown_files(input_dir);
+    files.sort();
     info!("Found {} markdown files", files.len());
 
     // Map: output html path -> output entry
@@ -185,12 +221,11 @@ pub fn process_markdown_files(
     let mut frontmatter_cache: FxHashMap<PathBuf, Option<PageFrontmatter>> =
       FxHashMap::default();
 
-    // First pass: render all files once and collect metadata
+    let cache = cache_dir.map(|dir| (dir, processor_digest(&base_processor)));
     let progress = ProgressBar::new(files.len() as u64);
     #[expect(
       clippy::expect_used,
-      reason = "template string is a compile-time constant; failure is \
-                impossible"
+      reason = "template string is a compile-time constant"
     )]
     let style = ProgressStyle::default_bar()
       .template(
@@ -203,24 +238,52 @@ pub fn process_markdown_files(
     progress.set_message("Processing markdown");
     progress.enable_steady_tick(std::time::Duration::from_millis(100));
 
-    for file_path in &files {
-      progress.inc(1);
-      let raw_content = fs::read_to_string(file_path).wrap_err_with(|| {
-        format!("Failed to read markdown file: {}", file_path.display())
-      })?;
+    let rendered: Result<Vec<_>> = files
+      .par_iter()
+      .progress_with(progress.clone())
+      .map(|file_path| {
+        let raw_content =
+          fs::read_to_string(file_path).wrap_err_with(|| {
+            format!("Failed to read markdown file: {}", file_path.display())
+          })?;
+        let base_dir = file_path.parent().unwrap_or(input_dir.as_path());
+        let source_digest = digest(&raw_content);
+        if let Some((dir, processor_digest)) = &cache
+          && let Some(entry) = read_cache(
+            dir,
+            file_path,
+            base_dir,
+            &source_digest,
+            processor_digest,
+          )
+        {
+          return Ok((file_path.clone(), entry.frontmatter, entry.result));
+        }
 
-      let (frontmatter, content) = strip_frontmatter(&raw_content);
+        let (frontmatter, content) = strip_frontmatter(&raw_content);
+        let result = base_processor
+          .clone()
+          .with_base_dir(base_dir)
+          .render(&content);
+        if let Some((dir, processor_digest)) = &cache {
+          write_cache(
+            dir,
+            file_path,
+            base_dir,
+            &source_digest,
+            processor_digest,
+            &result,
+            frontmatter.as_ref(),
+          );
+        }
+        Ok((file_path.clone(), frontmatter, result))
+      })
+      .collect();
+    progress.finish_with_message("Markdown processing complete");
+
+    for (file_path, frontmatter, result) in rendered? {
       frontmatter_cache.insert(file_path.clone(), frontmatter);
-
-      let base_dir = file_path.parent().unwrap_or_else(|| {
-        config
-          .input_dir
-          .as_deref()
-          .unwrap_or_else(|| Path::new("."))
-      });
-      let processor = base_processor.clone().with_base_dir(base_dir);
-
-      let result = processor.render(&content);
+      let base_dir = file_path.parent().unwrap_or(input_dir.as_path());
 
       // Track custom outputs for included files
       for inc in &result.included_files {
@@ -259,10 +322,8 @@ pub fn process_markdown_files(
       }
 
       // Cache the render result
-      render_cache.insert(file_path.clone(), result);
+      render_cache.insert(file_path, result);
     }
-
-    progress.finish_with_message("Markdown processing complete");
 
     // Second pass: use cached results to build output map
     for file_path in &files {
@@ -377,6 +438,128 @@ fn normalize_custom_output_path(path: &str) -> PathBuf {
   PathBuf::from(path.trim_start_matches('/'))
 }
 
+fn digest(content: impl AsRef<[u8]>) -> String {
+  blake3::hash(content.as_ref()).to_hex().to_string()
+}
+
+fn digest_file(path: &Path) -> Option<String> {
+  fs::read(path).ok().map(digest)
+}
+
+fn digest_tree(path: Option<&str>) -> String {
+  let Some(path) = path else {
+    return String::new();
+  };
+  let path = Path::new(path);
+  if path.is_file() {
+    return digest_file(path).unwrap_or_default();
+  }
+  let mut files: Vec<_> = walkdir::WalkDir::new(path)
+    .into_iter()
+    .filter_map(Result::ok)
+    .filter(|entry| !entry.file_type().is_dir())
+    .map(walkdir::DirEntry::into_path)
+    .collect();
+  files.sort();
+  let mut hasher = blake3::Hasher::new();
+  for file in files {
+    hasher.update(file.to_string_lossy().as_bytes());
+    if let Ok(content) = fs::read(&file) {
+      hasher.update(&content);
+    }
+  }
+  hasher.finalize().to_hex().to_string()
+}
+
+fn processor_digest(processor: &MarkdownProcessor) -> String {
+  processor_digest_for_version(processor, env!("CARGO_PKG_VERSION"))
+}
+
+fn processor_digest_for_version(
+  processor: &MarkdownProcessor,
+  version: &str,
+) -> String {
+  let options = processor.options();
+  digest(format!(
+    "{MARKDOWN_CACHE_SCHEMA}|{version}|{:?}|{}|{}|{}|{}|{}",
+    options,
+    digest_tree(options.manpage_urls_path.as_deref()),
+    digest_tree(options.syntax_queries_path.as_deref()),
+    cfg!(feature = "commonmark-ndg"),
+    cfg!(feature = "commonmark-nixpkgs"),
+    cfg!(feature = "commonmark-nixpkgs") || cfg!(feature = "commonmark-ndg"),
+  ))
+}
+
+fn cache_path(cache_dir: &Path, source: &Path) -> PathBuf {
+  cache_dir.join(format!(
+    "{}.json",
+    digest(source.to_string_lossy().as_bytes())
+  ))
+}
+
+fn read_cache(
+  cache_dir: &Path,
+  source: &Path,
+  base_dir: &Path,
+  source_digest: &str,
+  processor_digest: &str,
+) -> Option<MarkdownCacheEntry> {
+  let entry: MarkdownCacheEntry =
+    serde_json::from_slice(&fs::read(cache_path(cache_dir, source)).ok()?)
+      .ok()?;
+  if entry.schema != MARKDOWN_CACHE_SCHEMA
+    || entry.source_digest != source_digest
+    || entry.processor_digest != processor_digest
+  {
+    return None;
+  }
+  entry
+    .dependencies
+    .iter()
+    .all(|(path, expected)| digest_file(&base_dir.join(path)) == *expected)
+    .then_some(entry)
+}
+
+fn write_cache(
+  cache_dir: &Path,
+  source: &Path,
+  base_dir: &Path,
+  source_digest: &str,
+  processor_digest: &str,
+  result: &ndg_commonmark::MarkdownResult,
+  frontmatter: Option<&PageFrontmatter>,
+) {
+  let dependencies = result
+    .included_files
+    .iter()
+    .map(|include| {
+      let path = PathBuf::from(&include.path);
+      let digest = digest_file(&base_dir.join(&path));
+      (path, digest)
+    })
+    .collect();
+  let entry = MarkdownCacheEntry {
+    schema: MARKDOWN_CACHE_SCHEMA,
+    source_digest: source_digest.to_owned(),
+    dependencies,
+    processor_digest: processor_digest.to_owned(),
+    result: result.clone(),
+    frontmatter: frontmatter.cloned(),
+  };
+  let Ok(data) = serde_json::to_vec(&entry) else {
+    return;
+  };
+  if fs::create_dir_all(cache_dir).is_err() {
+    return;
+  }
+  let path = cache_path(cache_dir, source);
+  let temp = path.with_extension(format!("{}.tmp", std::process::id()));
+  if fs::write(&temp, data).is_ok() {
+    let _ = fs::rename(temp, path);
+  }
+}
+
 /// Creates a markdown processor from the NDG configuration.
 ///
 /// # Arguments
@@ -458,5 +641,143 @@ pub fn extract_page_title(file_path: &Path, html_path: &Path) -> String {
       );
       default_title
     },
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  #![allow(clippy::unwrap_used, reason = "Tests can unwrap")]
+
+  use ndg_commonmark::{IncludedFile, MarkdownResult};
+  use tempfile::TempDir;
+
+  use super::*;
+
+  #[test]
+  fn cache_rejects_changed_inputs() {
+    let temp = TempDir::new().unwrap();
+    let base = temp.path().join("docs");
+    let cache = temp.path().join("cache");
+    let source = base.join("page.md");
+    let include = base.join("part.md");
+    fs::create_dir_all(&base).unwrap();
+    fs::write(&source, "# Page").unwrap();
+    fs::write(&include, "included v1").unwrap();
+
+    let result = MarkdownResult {
+      html:           String::new(),
+      headers:        Vec::new(),
+      title:          None,
+      included_files: vec![IncludedFile {
+        path:          "part.md".to_string(),
+        custom_output: None,
+      }],
+    };
+    let source_digest = digest("# Page");
+    write_cache(
+      &cache,
+      &source,
+      &base,
+      &source_digest,
+      "processor-a",
+      &result,
+      None,
+    );
+
+    assert!(
+      read_cache(&cache, &source, &base, &source_digest, "processor-a")
+        .is_some(),
+      "unchanged inputs should reuse the cache"
+    );
+    assert!(
+      read_cache(&cache, &source, &base, &digest("# Changed"), "processor-a")
+        .is_none(),
+      "changed Markdown should invalidate the cache"
+    );
+
+    fs::write(&include, "included v2").unwrap();
+    assert!(
+      read_cache(&cache, &source, &base, &source_digest, "processor-a")
+        .is_none(),
+      "changed includes should invalidate the cache"
+    );
+
+    fs::write(&include, "included v1").unwrap();
+    assert!(
+      read_cache(&cache, &source, &base, &source_digest, "processor-b")
+        .is_none(),
+      "changed processor options should invalidate the cache"
+    );
+  }
+
+  #[test]
+  fn cache_rejects_a_dependency_that_appears() {
+    let temp = TempDir::new().unwrap();
+    let base = temp.path().join("docs");
+    let cache = temp.path().join("cache");
+    let source = base.join("page.md");
+    fs::create_dir_all(&base).unwrap();
+
+    let result = MarkdownResult {
+      html:           String::new(),
+      headers:        Vec::new(),
+      title:          None,
+      included_files: vec![IncludedFile {
+        path:          "missing.md".to_string(),
+        custom_output: None,
+      }],
+    };
+    let source_digest = digest("# Page");
+    write_cache(
+      &cache,
+      &source,
+      &base,
+      &source_digest,
+      "processor",
+      &result,
+      None,
+    );
+
+    assert!(
+      read_cache(&cache, &source, &base, &source_digest, "processor").is_some()
+    );
+    fs::write(base.join("missing.md"), "now available").unwrap();
+    assert!(
+      read_cache(&cache, &source, &base, &source_digest, "processor").is_none(),
+      "creating a previously missing include should invalidate the cache"
+    );
+  }
+
+  #[test]
+  fn processor_digest_tracks_query_files() {
+    let temp = TempDir::new().unwrap();
+    let queries = temp.path().join("queries");
+    fs::create_dir_all(&queries).unwrap();
+    fs::write(queries.join("highlights.scm"), "query v1").unwrap();
+    let config = Config {
+      syntax_queries_path: Some(queries.clone()),
+      ..Config::default()
+    };
+    let processor = create_processor(&config, None);
+    let before = processor_digest(&processor);
+
+    fs::write(queries.join("highlights.scm"), "query v2").unwrap();
+
+    assert_ne!(
+      before,
+      processor_digest(&processor),
+      "changed syntax queries should invalidate the cache"
+    );
+  }
+
+  #[test]
+  fn processor_digest_tracks_ndg_version() {
+    let processor = create_processor(&Config::default(), None);
+
+    assert_ne!(
+      processor_digest_for_version(&processor, "2.9.0"),
+      processor_digest_for_version(&processor, "2.10.0"),
+      "upgrading NDG should invalidate the cache"
+    );
   }
 }

--- a/ndg-commonmark/src/processor/core.rs
+++ b/ndg-commonmark/src/processor/core.rs
@@ -166,46 +166,7 @@ impl MarkdownProcessor {
     }
 
     let document = parse_html().one(html);
-
-    // Collect all code blocks first to avoid DOM modification during iteration
-    let mut code_blocks = Vec::new();
-    for pre_node in safe_select(&document, "pre > code") {
-      let code_node = pre_node;
-      if let Some(element) = code_node.as_element() {
-        let language = element
-          .attributes
-          .borrow()
-          .get("class")
-          .and_then(|class| class.strip_prefix("language-"))
-          .unwrap_or("text")
-          .to_string();
-        let code_text = code_node.text_contents();
-
-        if let Some(pre_parent) = code_node.parent() {
-          code_blocks.push((
-            pre_parent.clone(),
-            code_node.clone(),
-            code_text,
-            language,
-          ));
-        }
-      }
-    }
-
-    // Process each code block
-    for (pre_element, _code_node, code_text, language) in code_blocks {
-      if let Some(highlighted) = self.highlight_code_html(&code_text, &language)
-      {
-        // Wrap highlighted HTML in <pre><code> with appropriate classes
-        let wrapped_html = format!(
-          r#"<pre class="highlight"><code class="language-{language}">{highlighted}</code></pre>"#
-        );
-        let fragment = parse_html().one(wrapped_html.as_str());
-        pre_element.insert_after(fragment);
-        pre_element.detach();
-      }
-      // Do not add highlight/language-* classes if not highlighted
-    }
+    self.highlight_codeblocks_document(&document);
 
     let mut buf = Vec::new();
     if let Err(e) = document.serialize(&mut buf) {
@@ -300,8 +261,11 @@ impl MarkdownProcessor {
   #[must_use]
   pub fn render(&self, markdown: &str) -> MarkdownResult {
     let (preprocessed, included_files) = self.preprocess(markdown);
-    let (headers, title) = self.extract_headers(&preprocessed);
-    let html = self.process_html_pipeline(&preprocessed);
+    let arena = Arena::new();
+    let options = self.comrak_options();
+    let root = parse_document(&arena, &preprocessed, &options);
+    let (headers, title) = Self::extract_headers_from_ast(root, &preprocessed);
+    let html = self.process_html_pipeline_from_ast(root, &options);
 
     MarkdownResult {
       html,
@@ -311,30 +275,33 @@ impl MarkdownProcessor {
     }
   }
 
-  /// Process the HTML generation and post-processing pipeline.
-  fn process_html_pipeline(&self, content: &str) -> String {
-    let mut html = self.convert_to_html(content);
+  fn process_html_pipeline_from_ast<'a>(
+    &self,
+    root: &'a AstNode<'a>,
+    options: &Options<'a>,
+  ) -> String {
+    let mut html = Self::format_html(root, options);
+    self.process_rendered_html(&mut html);
+    html
+  }
 
+  fn process_rendered_html(&self, html: &mut String) {
     // Apply feature-specific post-processing
     if cfg!(feature = "ndg-flavored") {
       #[cfg(feature = "ndg-flavored")]
       {
-        html = super::extensions::process_option_references(
-          &html,
+        *html = super::extensions::process_option_references(
+          html,
           self.options.valid_options.as_ref(),
         );
       }
     }
 
     if self.options.nixpkgs {
-      html = self.process_manpage_references_html(&html);
+      *html = self.process_manpage_references_html(html);
     }
 
-    if self.options.highlight_code {
-      html = self.highlight_codeblocks(&html);
-    }
-
-    self.kuchiki_postprocess(&html)
+    *html = self.kuchiki_postprocess(html);
   }
 
   /// Preprocess the markdown content with all enabled transformations.
@@ -412,124 +379,122 @@ impl MarkdownProcessor {
     &self,
     content: &str,
   ) -> (Vec<Header>, Option<String>) {
-    use std::fmt::Write;
-
-    let arena = Arena::new();
-    let options = self.comrak_options();
-
-    let content = remove_admonition_blocks_for_headers(content);
-
-    // Normalize custom anchors with no heading level to h2
-    let mut normalized = String::with_capacity(content.len());
-    let mut lines = content.lines().peekable();
-    while let Some(line) = lines.next() {
-      let trimmed = line.trim();
-      if !trimmed.starts_with('#')
-        && !lines
-          .peek()
-          .is_some_and(|next| is_setext_heading_underline(next.trim()))
-        && let Some(anchor_start) = trimmed.rfind("{#")
-        && let Some(anchor_end) = trimmed[anchor_start..].find('}')
-      {
-        let text = trimmed[..anchor_start].trim_end();
-        let id = &trimmed[anchor_start + 2..anchor_start + anchor_end];
-        let _ = writeln!(normalized, "## {text} {{#{id}}}");
-        continue;
-      }
-      normalized.push_str(line);
-      normalized.push('\n');
-    }
-
-    let root = parse_document(&arena, &normalized, &options);
-
-    let mut headers = Vec::new();
-    let mut found_title = None;
-
-    for node in root.descendants() {
-      if let NodeValue::Heading(NodeHeading { level, .. }) =
-        &node.data.borrow().value
-      {
-        let mut text = String::new();
-        let mut explicit_id = None;
-
-        for child in node.children() {
-          match &child.data.borrow().value {
-            NodeValue::Text(t) => text.push_str(t),
-            NodeValue::Code(t) => text.push_str(&t.literal),
-            NodeValue::Link(..)
-            | NodeValue::Emph
-            | NodeValue::Strong
-            | NodeValue::Subscript
-            | NodeValue::Strikethrough
-            | NodeValue::Superscript
-            | NodeValue::FootnoteReference(..) => {
-              text.push_str(&extract_inline_text(child));
-            },
-            NodeValue::HtmlInline(html) => {
-              // Look for explicit anchor in HTML inline node: {#id}
-              let html_str = html.as_str();
-              if let Some(start) = html_str.find("{#")
-                && let Some(end) = html_str[start..].find('}')
-              {
-                let anchor = &html_str[start + 2..start + end];
-                explicit_id = Some(anchor.to_string());
-              }
-            },
-            #[expect(clippy::match_same_arms, reason = "Explicit for clarity")]
-            NodeValue::Image(..) => {},
-            _ => {},
-          }
-        }
-
-        // Check for trailing {#id} in heading text
-        let trimmed = text.trim_end();
-        #[expect(
-          clippy::option_if_let_else,
-          reason = "nested options clearer with if-let"
-        )]
-        let (final_text, id) = if let Some(start) = trimmed.rfind("{#") {
-          if let Some(end) = trimmed[start..].find('}') {
-            let anchor = &trimmed[start + 2..start + end];
-            (trimmed[..start].trim_end().to_string(), anchor.to_string())
-          } else {
-            (
-              text.clone(),
-              explicit_id.unwrap_or_else(|| slugify_heading(&text)),
-            )
-          }
-        } else {
-          (
-            text.clone(),
-            explicit_id.unwrap_or_else(|| slugify_heading(&text)),
-          )
-        };
-        if *level == 1 && found_title.is_none() {
-          found_title = Some(final_text.clone());
-        }
-        headers.push(Header {
-          text: final_text,
-          level: *level,
-          id,
-        });
-      }
-    }
-
-    (headers, found_title)
-  }
-
-  /// Convert markdown to HTML using comrak and configured options.
-  fn convert_to_html(&self, content: &str) -> String {
-    // Process directly without panic catching for better performance
     let arena = Arena::new();
     let options = self.comrak_options();
     let root = parse_document(&arena, content, &options);
+    Self::extract_headers_from_ast(root, content)
+  }
 
+  /// Extract headings from the already-rendered Comrak tree.
+  fn extract_headers_from_ast<'a>(
+    root: &'a AstNode<'a>,
+    source: &str,
+  ) -> (Vec<Header>, Option<String>) {
+    let mut headers = Vec::new();
+    let mut title = None;
+    let ignored_lines = admonition_lines(source);
+    for node in root.descendants() {
+      let NodeValue::Heading(NodeHeading { level, .. }) =
+        &node.data.borrow().value
+      else {
+        continue;
+      };
+      let line = node.data.borrow().sourcepos.start.line;
+      if ignored_lines.get(line).copied().unwrap_or(false) {
+        continue;
+      }
+      let mut text = String::new();
+      let mut explicit_id = None;
+      for child in node.children() {
+        match &child.data.borrow().value {
+          NodeValue::Text(value) => text.push_str(value),
+          NodeValue::Code(value) => text.push_str(&value.literal),
+          NodeValue::Link(..)
+          | NodeValue::Emph
+          | NodeValue::Strong
+          | NodeValue::Subscript
+          | NodeValue::Strikethrough
+          | NodeValue::Superscript
+          | NodeValue::FootnoteReference(..) => {
+            text.push_str(&extract_inline_text(child));
+          },
+          NodeValue::HtmlInline(value) => {
+            if let Some(start) = value.find("{#")
+              && let Some(end) = value[start..].find('}')
+            {
+              explicit_id = Some(value[start + 2..start + end].to_string());
+            }
+          },
+          _ => {},
+        }
+      }
+      let trimmed = text.trim_end();
+      let (text, id) = if let Some(start) = trimmed.rfind("{#")
+        && let Some(end) = trimmed[start..].find('}')
+      {
+        (
+          trimmed[..start].trim_end().to_string(),
+          trimmed[start + 2..start + end].to_string(),
+        )
+      } else {
+        (
+          text.clone(),
+          explicit_id.unwrap_or_else(|| slugify_heading(&text)),
+        )
+      };
+      if *level == 1 && title.is_none() {
+        title = Some(text.clone());
+      }
+      headers.push((line, Header {
+        text,
+        level: *level,
+        id,
+      }));
+    }
+    let lines: Vec<_> = source.lines().collect();
+    let mut fence = utils::codeblock::FenceTracker::new();
+    for (index, line) in lines.iter().enumerate() {
+      fence = fence.process_line(line);
+      if ignored_lines.get(index + 1).copied().unwrap_or(false) {
+        continue;
+      }
+      if fence.in_code_block() {
+        continue;
+      }
+      let trimmed = line.trim();
+      if trimmed.starts_with('#')
+        || lines
+          .get(index + 1)
+          .is_some_and(|next| is_setext_heading_underline(next.trim()))
+      {
+        continue;
+      }
+      if let Some(start) = trimmed.rfind("{#")
+        && let Some(end) = trimmed[start..].find('}')
+      {
+        let text = trimmed[..start].trim_end();
+        let id = &trimmed[start + 2..start + end];
+        headers.push((index + 1, Header {
+          text:  text.to_string(),
+          level: 2,
+          id:    id.to_string(),
+        }));
+      }
+    }
+    headers.sort_by_key(|(line, _)| *line);
+    (
+      headers.into_iter().map(|(_, header)| header).collect(),
+      title,
+    )
+  }
+
+  fn format_html<'a>(root: &'a AstNode<'a>, options: &Options<'a>) -> String {
     // Apply AST transformations
     let prompt_transformer = PromptTransformer;
     prompt_transformer.transform(root);
 
     let mut html_output = String::new();
-    if let Err(e) = comrak::format_html(root, &options, &mut html_output) {
+    if let Err(e) = comrak::format_html(root, options, &mut html_output) {
       log::error!("Failed to format HTML: {e}");
     }
 
@@ -658,15 +623,43 @@ impl MarkdownProcessor {
   }
 
   /// HTML post-processing using kuchiki DOM manipulation.
-  #[expect(
-    clippy::unused_self,
-    reason = "Method signature matches processor pattern"
-  )]
   fn kuchiki_postprocess(&self, html: &str) -> String {
     // Use a standalone function to avoid borrowing issues
     kuchiki_postprocess_html(html, |document| {
+      self.highlight_codeblocks_document(document);
       Self::apply_dom_transformations(document);
     })
+  }
+
+  fn highlight_codeblocks_document(&self, document: &kuchikikiki::NodeRef) {
+    if !self.options.highlight_code || self.syntax_manager.is_none() {
+      return;
+    }
+    let mut code_blocks = Vec::new();
+    for code_node in safe_select(document, "pre > code") {
+      if let Some(element) = code_node.as_element() {
+        let language = element
+          .attributes
+          .borrow()
+          .get("class")
+          .and_then(|class| class.strip_prefix("language-"))
+          .unwrap_or("text")
+          .to_string();
+        if let Some(pre_node) = code_node.parent() {
+          code_blocks.push((pre_node, code_node.text_contents(), language));
+        }
+      }
+    }
+    for (pre_node, code, language) in code_blocks {
+      if let Some(highlighted) = self.highlight_code_html(&code, &language) {
+        use tendril::TendrilSink;
+        let replacement = kuchikikiki::parse_html().one(format!(
+          r#"<pre class="highlight"><code class="language-{language}">{highlighted}</code></pre>"#
+        ));
+        pre_node.insert_after(replacement);
+        pre_node.detach();
+      }
+    }
   }
 
   /// Apply all DOM transformations to the parsed HTML document.
@@ -1382,31 +1375,24 @@ pub enum ProcessorFeature {
   ManpageUrls,
 }
 
-fn remove_admonition_blocks_for_headers(content: &str) -> String {
-  let mut output = String::with_capacity(content.len());
-  let mut admonition_depth = 0usize;
+fn admonition_lines(content: &str) -> Vec<bool> {
+  let mut ignored = vec![false; content.lines().count() + 1];
+  let mut depth = 0usize;
 
-  for line in content.lines() {
+  for (index, line) in content.lines().enumerate() {
     let trimmed = line.trim_start();
     if trimmed.starts_with("<div class=\"admonition ") {
-      admonition_depth += 1;
-      output.push('\n');
-      continue;
+      depth += 1;
     }
-
-    if admonition_depth > 0 {
-      if trimmed == "</div>" {
-        admonition_depth -= 1;
-      }
-      output.push('\n');
-      continue;
+    if depth > 0 {
+      ignored[index + 1] = true;
     }
-
-    output.push_str(line);
-    output.push('\n');
+    if depth > 0 && trimmed == "</div>" {
+      depth -= 1;
+    }
   }
 
-  output
+  ignored
 }
 
 fn is_setext_heading_underline(line: &str) -> bool {

--- a/ndg-commonmark/src/processor/extensions.rs
+++ b/ndg-commonmark/src/processor/extensions.rs
@@ -263,30 +263,27 @@ fn read_options_includes(
     }
 
     let full_path = base_dir.join(trimmed);
-    match fs::read_to_string(&full_path) {
-      Ok(content) => {
-        if let Some(rendered) = render_options_include(&content) {
-          result.push_str(&rendered);
-        } else {
-          let _ = writeln!(
-            result,
-            "<!-- ndg: could not parse options include: {} -->",
-            full_path.display()
-          );
-        }
-        included_files.push(crate::types::IncludedFile {
-          path:          trimmed.to_string(),
-          custom_output: None,
-        });
-      },
-      Err(_) => {
+    if let Ok(content) = fs::read_to_string(&full_path) {
+      if let Some(rendered) = render_options_include(&content) {
+        result.push_str(&rendered);
+      } else {
         let _ = writeln!(
           result,
-          "<!-- ndg: could not include file: {} -->",
+          "<!-- ndg: could not parse options include: {} -->",
           full_path.display()
         );
-      },
+      }
+    } else {
+      let _ = writeln!(
+        result,
+        "<!-- ndg: could not include file: {} -->",
+        full_path.display()
+      );
     }
+    included_files.push(crate::types::IncludedFile {
+      path:          trimmed.to_string(),
+      custom_output: None,
+    });
   }
 
   result
@@ -316,30 +313,27 @@ fn read_options_file(
   }
 
   let full_path = base_dir.join(source);
-  match fs::read_to_string(&full_path) {
-    Ok(content) => {
-      if let Some(rendered) = render_options_include(&content) {
-        result.push_str(&rendered);
-      } else {
-        let _ = writeln!(
-          result,
-          "<!-- ndg: could not parse options include: {} -->",
-          full_path.display()
-        );
-      }
-      included_files.push(crate::types::IncludedFile {
-        path:          source.to_string(),
-        custom_output: None,
-      });
-    },
-    Err(_) => {
+  if let Ok(content) = fs::read_to_string(&full_path) {
+    if let Some(rendered) = render_options_include(&content) {
+      result.push_str(&rendered);
+    } else {
       let _ = writeln!(
         result,
-        "<!-- ndg: could not include file: {} -->",
+        "<!-- ndg: could not parse options include: {} -->",
         full_path.display()
       );
-    },
+    }
+  } else {
+    let _ = writeln!(
+      result,
+      "<!-- ndg: could not include file: {} -->",
+      full_path.display()
+    );
   }
+  included_files.push(crate::types::IncludedFile {
+    path:          source.to_string(),
+    custom_output: None,
+  });
 
   result
 }
@@ -368,54 +362,54 @@ fn read_includes(
     let full_path = base_dir.join(trimmed);
     log::info!("Including file: {}", full_path.display());
 
-    match fs::read_to_string(&full_path) {
-      Ok(content) => {
-        let file_dir = full_path.parent().unwrap_or(base_dir);
-        let (processed_content, nested_includes) =
-          process_file_includes(&content, file_dir, depth + 1)?;
+    if let Ok(content) = fs::read_to_string(&full_path) {
+      let file_dir = full_path.parent().unwrap_or(base_dir);
+      let (processed_content, nested_includes) =
+        process_file_includes(&content, file_dir, depth + 1)?;
 
-        let processed_content = if let Some(prefix) = auto_id_prefix.as_deref()
-        {
-          apply_auto_id_prefix(
-            &processed_content,
-            &format!("{}-{}", prefix, line_index + 1),
-          )
-        } else {
-          processed_content
-        };
+      let processed_content = if let Some(prefix) = auto_id_prefix.as_deref() {
+        apply_auto_id_prefix(
+          &processed_content,
+          &format!("{}-{}", prefix, line_index + 1),
+        )
+      } else {
+        processed_content
+      };
 
-        if custom_output.is_none() {
-          result.push_str(&processed_content);
-          if !processed_content.ends_with('\n') {
-            result.push('\n');
-          }
-          result.push_str(INCLUDE_BOUNDARY_MARKER);
+      if custom_output.is_none() {
+        result.push_str(&processed_content);
+        if !processed_content.ends_with('\n') {
           result.push('\n');
         }
+        result.push_str(INCLUDE_BOUNDARY_MARKER);
+        result.push('\n');
+      }
 
-        included_files.push(crate::types::IncludedFile {
-          path:          trimmed.to_string(),
-          custom_output: custom_output.clone(),
-        });
+      included_files.push(crate::types::IncludedFile {
+        path:          trimmed.to_string(),
+        custom_output: custom_output.clone(),
+      });
 
-        // Normalize nested include paths relative to original base_dir
-        for nested in nested_includes {
-          let nested_full_path = file_dir.join(&nested.path);
-          if let Ok(normalized_path) = nested_full_path.strip_prefix(base_dir) {
-            included_files.push(crate::types::IncludedFile {
-              path:          normalized_path.to_string_lossy().to_string(),
-              custom_output: nested.custom_output,
-            });
-          }
+      // Normalize nested include paths relative to original base_dir
+      for nested in nested_includes {
+        let nested_full_path = file_dir.join(&nested.path);
+        if let Ok(normalized_path) = nested_full_path.strip_prefix(base_dir) {
+          included_files.push(crate::types::IncludedFile {
+            path:          normalized_path.to_string_lossy().to_string(),
+            custom_output: nested.custom_output,
+          });
         }
-      },
-      Err(_) => {
-        let _ = writeln!(
-          result,
-          "<!-- ndg: could not include file: {} -->",
-          full_path.display()
-        );
-      },
+      }
+    } else {
+      let _ = writeln!(
+        result,
+        "<!-- ndg: could not include file: {} -->",
+        full_path.display()
+      );
+      included_files.push(crate::types::IncludedFile {
+        path:          trimmed.to_string(),
+        custom_output: custom_output.clone(),
+      });
     }
   }
   Ok(result)

--- a/ndg-commonmark/src/syntax/syntastica.rs
+++ b/ndg-commonmark/src/syntax/syntastica.rs
@@ -45,8 +45,13 @@ use super::{
 pub struct SyntasticaHighlighter {
   themes:        FxHashMap<String, ResolvedTheme>,
   default_theme: ResolvedTheme,
-  processor:     Mutex<Processor<'static, UserQueryLanguageSet>>,
-  renderer:      Mutex<HtmlRenderer>,
+  language_set:  &'static UserQueryLanguageSet,
+  workers:       Mutex<Vec<HighlightWorker>>,
+}
+
+struct HighlightWorker {
+  processor: Processor<'static, UserQueryLanguageSet>,
+  renderer:  HtmlRenderer,
 }
 
 struct UserQueryLanguageSet {
@@ -347,13 +352,11 @@ impl SyntasticaHighlighter {
     // raw-pointer cast would require.
     let language_set_static: &'static UserQueryLanguageSet =
       Box::leak(Box::new(UserQueryLanguageSet::new(syntax_queries_dir)));
-    let processor = Processor::new(language_set_static);
-
     Ok(Self {
       themes,
       default_theme,
-      processor: Mutex::new(processor),
-      renderer: Mutex::new(HtmlRenderer::new()),
+      language_set: language_set_static,
+      workers: Mutex::new(Vec::new()),
     })
   }
 
@@ -507,25 +510,39 @@ impl SyntaxHighlighter for SyntasticaHighlighter {
 
     let theme = self.get_theme(theme);
 
-    // Use the reusable processor via Mutex for thread-safe interior mutability
-    let highlights = self
-      .processor
+    let mut worker = self
+      .workers
       .lock()
       .map_err(|e| {
-        SyntaxError::HighlightingFailed(format!("Processor lock poisoned: {e}"))
+        SyntaxError::HighlightingFailed(format!(
+          "Worker pool lock poisoned: {e}"
+        ))
       })?
+      .pop()
+      .unwrap_or_else(|| {
+        HighlightWorker {
+          processor: Processor::new(self.language_set),
+          renderer:  HtmlRenderer::new(),
+        }
+      });
+
+    let result = worker
+      .processor
       .process(code, lang)
-      .map_err(|e| SyntaxError::HighlightingFailed(e.to_string()))?;
+      .map(|highlights| render(&highlights, &mut worker.renderer, theme))
+      .map_err(|e| SyntaxError::HighlightingFailed(e.to_string()));
 
-    // Use the reusable renderer via Mutex for thread-safe interior mutability
-    let html = {
-      let mut renderer = self.renderer.lock().map_err(|e| {
-        SyntaxError::HighlightingFailed(format!("Renderer lock poisoned: {e}"))
-      })?;
-      render(&highlights, &mut *renderer, theme)
-    };
+    self
+      .workers
+      .lock()
+      .map_err(|e| {
+        SyntaxError::HighlightingFailed(format!(
+          "Worker pool lock poisoned: {e}"
+        ))
+      })?
+      .push(worker);
 
-    Ok(html)
+    result
   }
 
   fn language_from_extension(&self, extension: &str) -> Option<String> {

--- a/ndg-commonmark/tests/header_extraction.rs
+++ b/ndg-commonmark/tests/header_extraction.rs
@@ -7,8 +7,9 @@ fn extract_headers_from_markdown(md: &str) -> Vec<Header> {
     ..Default::default()
   };
   let processor = MarkdownProcessor::new(options);
-  let (headers, _title) = processor.extract_headers(md);
-  headers
+  let rendered = processor.render(md).headers;
+  assert_eq!(processor.extract_headers(md).0, rendered);
+  rendered
 }
 
 #[test]
@@ -61,6 +62,8 @@ fn test_no_headers_from_code_block() {
 
   ```markdown
   ## Installation {#my-epic-installation}
+
+  Not a heading {#not-a-heading}
 
   Refer to the [installation instructions](#my-epic-installation) above.
   ```

--- a/ndg-commonmark/tests/markup.rs
+++ b/ndg-commonmark/tests/markup.rs
@@ -1207,6 +1207,8 @@ test1.md
 
     // Should show include processing (file not found)
     assert!(result.html.contains("<!-- ndg: could not include file:"));
+    assert_eq!(result.included_files.len(), 1);
+    assert_eq!(result.included_files[0].path, "test1.md");
   }
 }
 

--- a/ndg/Cargo.toml
+++ b/ndg/Cargo.toml
@@ -73,5 +73,9 @@ tempfile.workspace  = true
 harness = false
 name    = "postprocess"
 
+[[bench]]
+harness = false
+name    = "markdown"
+
 [lints]
 workspace = true

--- a/ndg/README.md
+++ b/ndg/README.md
@@ -191,28 +191,13 @@ $ ndg html --config-file base.toml --config-file overrides.toml
 $ ndg html --config search.enable=false --config sidebar.options.depth=3
 ```
 
-Upon running `ndg init`, you will receive a configuration file in one of JSON or
-TOML formats depending on the format specified, with all available options and
-their default values as well as explanatory comments. You can then edit this
-file to customize your documentation generation process.
-
 > [!TIP]
-> The generated configuration includes detailed comments for each option, making
-> it easy to understand what each setting does without needing to refer to the
-> documentation.
-
-Once you have a configuration file, NDG will automatically detect it when ran in
-the same directory. Though if you want to move the configuration file to a
-nonstandard location, you may specify a path to the configuration file using the
-`--config-file` option.
-
-```bash
-# Run with automatically detected config
-$ ndg html
-
-# Run with explicitly specified config
-$ ndg html --config-file nested/path/to/ndg.toml
-```
+> Repeated HTML builds keep Markdown render entries in `.ndg-cache/markdown/`
+> below the project directory. For an explicit configuration, this is the
+> directory containing the first configuration file; otherwise it is the working
+> directory. The cache is safe to delete and is ignored when it cannot be read
+> or written. `ndg init` will automatically append this directory to your
+> `.gitignore` if present, or will create a `.gitignore` if none is found.
 
 ### Generating Your First Documents
 
@@ -597,7 +582,7 @@ robots = "index,follow"
 
 ### Generating HTML Documents
 
-As of `v2.0.0`, NDG features a more compartmentalized architechture with a focus
+As of `v2.0.0`, NDG features a more compartmentalized architecture with a focus
 on distinguishing between output formats more carefully. Prior to version 2.0.0,
 HTML was the "default" output format, and the only "blessed" one.
 
@@ -695,7 +680,11 @@ The extractor currently documents only statically named attribute bindings.
 Dynamic attribute paths are skipped, syntax errors are handled using `rnix`'s
 error-tolerant syntax tree, and comments that the `nixdoc` parser rejects remain
 available only as raw comments. Treat generated library references as output to
-review, especially for malformed or highly dynamic Nix sources.
+review, especially for malformed or highly dynamic Nix sources. This feature
+uses a [tiny in-house crate](https://crates.io/crates/nixdoc) which has an
+unfortunate name collision with the "official" `nixdoc` tool. The parser is
+entirely in-house and acts as a library. `ndg-nixdoc` and by extension, ndg,
+does not call `nixdoc` as a CLI tool.
 
 ### Generating Manpages
 
@@ -711,8 +700,8 @@ $ ndg man -j ./options.json --output-file ./man/project.5 --title "My Project" -
 
 > [!NOTE]
 > For manpages, you **must** provide an `options.json` using `--module-options`
-> or `-j`. Since we do not convert arbitrary pages in the Manpages mode, this is
-> necessary to generate the main page containing module options.
+> or `-j`. Since we **do not yet** convert arbitrary pages in the Manpages mode,
+> this is necessary to generate the main page containing module options.
 
 ### Generating PDFs
 

--- a/ndg/benches/markdown.rs
+++ b/ndg/benches/markdown.rs
@@ -1,0 +1,124 @@
+#![expect(clippy::unwrap_used, reason = "Fine in benchmarks")]
+
+use std::{fs, hint::black_box, path::Path};
+
+use criterion::{Criterion, criterion_group, criterion_main};
+use ndg::{
+  config::Config,
+  utils::{
+    create_processor,
+    process_markdown_files,
+    process_markdown_files_with_cache,
+  },
+};
+use tempfile::TempDir;
+
+const PAGE_COUNT: usize = 128;
+
+fn fixture() -> TempDir {
+  let dir = TempDir::new().unwrap();
+  let input = dir.path().join("docs");
+  fs::create_dir_all(input.join("includes/nested")).unwrap();
+  fs::write(
+    input.join("includes/part.md"),
+    "## Included section\n\n{#included-anchor}\n\n```nix\n{ pkgs, ... }: \
+     pkgs.hello\n```\n\n```{=include=}\nnested/detail.md\n```\n",
+  )
+  .unwrap();
+  fs::write(
+    input.join("includes/nested/detail.md"),
+    "### Nested include\n\nA nested [reference](../page-000.md).\n",
+  )
+  .unwrap();
+  for index in 0..PAGE_COUNT {
+    fs::write(
+      input.join(format!("page-{index:03}.md")),
+      format!(
+        r#"+++
+title = "Benchmark page {index}"
+tags = ["benchmark", "markdown"]
++++
+# Benchmark page {index}
+
+[Next page](page-{:03}.md)
+
+```{{=include=}}
+includes/part.md
+```
+
+## Rendering path
+
+```nix
+let value = {index}; in value + 1
+```
+"#,
+        (index + 1) % PAGE_COUNT,
+      ),
+    )
+    .unwrap();
+  }
+  dir
+}
+
+fn config(root: &Path, highlight_code: bool) -> Config {
+  Config {
+    input_dir: Some(root.join("docs")),
+    highlight_code,
+    ..Config::default()
+  }
+}
+
+fn markdown(c: &mut Criterion) {
+  let fixture = fixture();
+  let cache = fixture.path().join("cache");
+  let plain_processor = create_processor(&config(fixture.path(), false), None);
+  let highlighted_processor =
+    create_processor(&config(fixture.path(), true), None);
+  let mut group = c.benchmark_group("markdown-site-128-pages");
+
+  group.bench_function("plain", |b| {
+    b.iter(|| {
+      let mut config = config(fixture.path(), false);
+      black_box(
+        process_markdown_files(&mut config, Some(&plain_processor)).unwrap(),
+      );
+    });
+  });
+
+  {
+    let mut config = config(fixture.path(), true);
+    process_markdown_files_with_cache(
+      &mut config,
+      Some(&highlighted_processor),
+      &cache,
+    )
+    .unwrap();
+  }
+  group.bench_function("warm-cache", |b| {
+    b.iter(|| {
+      let mut config = config(fixture.path(), true);
+      black_box(
+        process_markdown_files_with_cache(
+          &mut config,
+          Some(&highlighted_processor),
+          &cache,
+        )
+        .unwrap(),
+      );
+    });
+  });
+
+  group.bench_function("highlighted", |b| {
+    b.iter(|| {
+      let mut config = config(fixture.path(), true);
+      black_box(
+        process_markdown_files(&mut config, Some(&highlighted_processor))
+          .unwrap(),
+      );
+    });
+  });
+  group.finish();
+}
+
+criterion_group!(benches, markdown);
+criterion_main!(benches);

--- a/ndg/src/main.rs
+++ b/ndg/src/main.rs
@@ -67,6 +67,7 @@ fn main() -> Result<()> {
             )
           },
         )?;
+        update_gitignore(output)?;
 
         info!(
           "Configuration file created successfully. Edit it to customize your \
@@ -126,6 +127,7 @@ fn main() -> Result<()> {
     }
   }
 
+  let project_root = project_root(&cli.config_files);
   let mut config = Config::load(&cli.config_files, &cli.config_overrides)?;
   merge_cli_into_config(&mut config, &cli);
 
@@ -150,7 +152,10 @@ fn main() -> Result<()> {
   }
 
   if output_mode.generate_html() {
-    generate_documentation(&mut config)?;
+    generate_documentation(
+      &mut config,
+      &project_root.join(".ndg-cache/markdown"),
+    )?;
   }
   if output_mode.generate_man() {
     generate_man_output(&config)?;
@@ -179,8 +184,53 @@ fn main() -> Result<()> {
   Ok(())
 }
 
+fn update_gitignore(config_path: &Path) -> Result<()> {
+  const CACHE_ENTRY: &str = ".ndg-cache/";
+  const CACHE_SECTION: &str = "# NDG generated cache\n.ndg-cache/\n";
+
+  let root = config_path
+    .parent()
+    .filter(|path| !path.as_os_str().is_empty())
+    .unwrap_or_else(|| Path::new("."));
+  let path = root.join(".gitignore");
+  let mut content = if path.exists() {
+    fs::read_to_string(&path)
+      .wrap_err_with(|| format!("Failed to read {}", path.display()))?
+  } else {
+    String::new()
+  };
+
+  if content.lines().any(|line| line.trim() == CACHE_ENTRY) {
+    return Ok(());
+  }
+  if !content.is_empty() {
+    if !content.ends_with('\n') {
+      content.push('\n');
+    }
+    content.push('\n');
+  }
+  content.push_str(CACHE_SECTION);
+  fs::write(&path, content)
+    .wrap_err_with(|| format!("Failed to update {}", path.display()))
+}
+
+fn project_root(config_files: &[PathBuf]) -> PathBuf {
+  config_files
+    .first()
+    .and_then(|path| path.parent())
+    .filter(|path| !path.as_os_str().is_empty())
+    .map_or_else(
+      || std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")),
+      Path::to_path_buf,
+    )
+}
+
 #[cfg(test)]
 mod tests {
+  #![allow(clippy::unwrap_used, reason = "Tests can unwrap")]
+
+  use tempfile::tempdir;
+
   use super::*;
 
   fn processed(output_path: &str) -> utils::markdown::ProcessedMarkdown {
@@ -207,6 +257,31 @@ mod tests {
     let processed_markdown = vec![processed("index.html")];
 
     assert!(has_root_homepage(&processed_markdown));
+  }
+
+  #[test]
+  fn init_creates_or_updates_gitignore_idempotently() {
+    let temp = tempdir().unwrap();
+    let new_project = temp.path().join("new");
+    fs::create_dir(&new_project).unwrap();
+    update_gitignore(&new_project.join("ndg.toml")).unwrap();
+    assert_eq!(
+      fs::read_to_string(new_project.join(".gitignore")).unwrap(),
+      "# NDG generated cache\n.ndg-cache/\n"
+    );
+
+    let existing_project = temp.path().join("existing");
+    fs::create_dir(&existing_project).unwrap();
+    let gitignore = existing_project.join(".gitignore");
+    fs::write(&gitignore, "result\n").unwrap();
+    let config = existing_project.join("custom.toml");
+    update_gitignore(&config).unwrap();
+    update_gitignore(&config).unwrap();
+    assert_eq!(
+      fs::read_to_string(gitignore).unwrap(),
+      "result\n\n# NDG generated cache\n.ndg-cache/\n"
+    );
+    assert_eq!(project_root(&[config]), existing_project);
   }
 }
 
@@ -403,7 +478,7 @@ fn has_root_homepage(
 }
 
 /// Main documentation generation process
-fn generate_documentation(config: &mut Config) -> Result<()> {
+fn generate_documentation(config: &mut Config, cache_dir: &Path) -> Result<()> {
   info!("Starting documentation generation...");
 
   // Validate required paths after CLI merge
@@ -441,8 +516,11 @@ fn generate_documentation(config: &mut Config) -> Result<()> {
   // As a side effect, this populates config.included_files so that the
   // sidebar navigation can correctly filter out included files.
   info!("Processing markdown files...");
-  let mut processed_markdown =
-    utils::process_markdown_files(config, processor.as_ref())?;
+  let mut processed_markdown = utils::process_markdown_files_with_cache(
+    config,
+    processor.as_ref(),
+    cache_dir,
+  )?;
   info!("Processed {} markdown files", processed_markdown.len());
 
   // Build a global anchor registry from all pages and rewrite cross-page


### PR DESCRIPTION
Bunch of performance improvements to ndg's markdown processing pipeline and a proper highlighting cache. The changes cause the previous 128-page benchmarks to change from

- Plain: 5.42 ms
- Warm cache: 1.77 ms
- Highlighted: 32.69 ms

to 19.1 ms, 4.6 ms, and 57.2 ms respectively. I've refactored the `SyntasticaHighlighter` to use a pool of worker structs, separating the language set and renderer, which gets us closer to proper concurrency. Real concurrency has never been tried btw.