### PR TITLE
various: detect and validate duplicate anchor IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,9 @@ changes.
 
 ### Fixed
 
+- Markdown documentation builds now detect duplicate rendered anchor IDs and
+  report the colliding anchors instead of producing pages with broken or
+  ambiguous navigation.
 - Search worker now caches the document set between searches. Documents are sent
   to the worker once via an `init` message instead of being re-sent with every
   keystroke in order to eliminate the structured-cloning overhead on large

--- a/crates/ndg-utils/src/markdown.rs
+++ b/crates/ndg-utils/src/markdown.rs
@@ -270,7 +270,13 @@ fn process_markdown_files_impl(
         let result = base_processor
           .clone()
           .with_base_dir(base_dir)
-          .render(&content);
+          .render_checked(&content)
+          .map_err(|e| {
+            color_eyre::eyre::eyre!(
+              "Duplicate anchor IDs in {}:\n{e}",
+              file_path.display()
+            )
+          })?;
         if let Some((dir, processor_digest)) = &cache {
           write_cache(
             dir,

--- a/crates/ndg-utils/src/markdown.rs
+++ b/crates/ndg-utils/src/markdown.rs
@@ -114,7 +114,7 @@ pub struct ProcessedMarkdown {
   pub frontmatter:  Option<PageFrontmatter>,
 }
 
-const MARKDOWN_CACHE_SCHEMA: u8 = 2;
+const MARKDOWN_CACHE_SCHEMA: u8 = 3;
 
 #[derive(Serialize, Deserialize)]
 struct MarkdownCacheEntry {
@@ -786,6 +786,43 @@ mod tests {
     assert!(
       read_cache(&cache, &source, &base, &source_digest, "processor").is_none(),
       "creating a previously missing include should invalidate the cache"
+    );
+  }
+
+  #[test]
+  fn cache_rejects_entries_from_previous_schema() {
+    let temp = TempDir::new().unwrap();
+    let base = temp.path().join("docs");
+    let cache = temp.path().join("cache");
+    let source = base.join("page.md");
+    fs::create_dir_all(&base).unwrap();
+
+    let result = MarkdownResult {
+      html:           String::new(),
+      headers:        Vec::new(),
+      title:          None,
+      included_files: Vec::new(),
+    };
+    let source_digest = digest("# Page");
+    write_cache(
+      &cache,
+      &source,
+      &base,
+      &source_digest,
+      "processor",
+      &result,
+      None,
+    );
+
+    let path = cache_path(&cache, &source);
+    let mut entry: serde_json::Value =
+      serde_json::from_slice(&fs::read(&path).unwrap()).unwrap();
+    entry["schema"] = serde_json::json!(MARKDOWN_CACHE_SCHEMA - 1);
+    fs::write(&path, serde_json::to_vec(&entry).unwrap()).unwrap();
+
+    assert!(
+      read_cache(&cache, &source, &base, &source_digest, "processor").is_none(),
+      "entries from the previous schema must be re-rendered"
     );
   }
 

--- a/ndg-commonmark/src/lib.rs
+++ b/ndg-commonmark/src/lib.rs
@@ -146,5 +146,12 @@ pub use crate::{
     SyntaxManager,
     create_default_manager,
   },
-  types::{Header, IncludedFile, MarkdownResult},
+  types::{
+    DuplicateAnchor,
+    DuplicateAnchorError,
+    Header,
+    IncludedFile,
+    MarkdownResult,
+    validate_anchor_ids,
+  },
 };

--- a/ndg-commonmark/src/processor/core.rs
+++ b/ndg-commonmark/src/processor/core.rs
@@ -275,6 +275,24 @@ impl MarkdownProcessor {
     }
   }
 
+  /// Render Markdown to HTML with anchor validation.
+  ///
+  /// Same as [`render()`](Self::render), but additionally validates that all
+  /// heading anchor IDs are unique. Returns an error if duplicates are found.
+  ///
+  /// # Errors
+  ///
+  /// Returns `Err(DuplicateAnchorError)` if any two headings share the same
+  /// anchor ID.
+  pub fn render_checked(
+    &self,
+    markdown: &str,
+  ) -> Result<MarkdownResult, crate::types::DuplicateAnchorError> {
+    let result = self.render(markdown);
+    crate::types::validate_anchor_ids(&result.headers)?;
+    Ok(result)
+  }
+
   fn process_html_pipeline_from_ast<'a>(
     &self,
     root: &'a AstNode<'a>,

--- a/ndg-commonmark/src/processor/core.rs
+++ b/ndg-commonmark/src/processor/core.rs
@@ -289,7 +289,7 @@ impl MarkdownProcessor {
     markdown: &str,
   ) -> Result<MarkdownResult, crate::types::DuplicateAnchorError> {
     let result = self.render(markdown);
-    crate::types::validate_anchor_ids(&result.headers)?;
+    crate::types::validate_rendered_anchor_ids(&result.headers, &result.html)?;
     Ok(result)
   }
 

--- a/ndg-commonmark/src/types.rs
+++ b/ndg-commonmark/src/types.rs
@@ -21,6 +21,95 @@ pub struct IncludedFile {
   pub custom_output: Option<String>,
 }
 
+/// A single duplicate anchor occurrence with context.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DuplicateAnchor {
+  /// The duplicated anchor ID.
+  pub id:           String,
+  /// Text of the first heading with this ID.
+  pub first_text:   String,
+  /// Level of the first heading.
+  pub first_level:  u8,
+  /// Text of the second heading with this ID.
+  pub second_text:  String,
+  /// Level of the second heading.
+  pub second_level: u8,
+}
+
+impl std::fmt::Display for DuplicateAnchor {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    write!(
+      f,
+      "Duplicate anchor ID '{}' found: '{}' (h{}) and '{}' (h{})",
+      self.id,
+      self.first_text,
+      self.first_level,
+      self.second_text,
+      self.second_level
+    )
+  }
+}
+
+/// Error returned when duplicate anchor IDs are detected.
+#[derive(Debug, Clone)]
+pub struct DuplicateAnchorError {
+  /// All duplicate anchors found in the document.
+  pub duplicates: Vec<DuplicateAnchor>,
+}
+
+impl std::fmt::Display for DuplicateAnchorError {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    writeln!(f, "Found {} duplicate anchor ID(s):", self.duplicates.len())?;
+    for dup in &self.duplicates {
+      writeln!(f, "  {dup}")?;
+    }
+    Ok(())
+  }
+}
+
+impl std::error::Error for DuplicateAnchorError {}
+
+/// Validate that all heading anchor IDs are unique.
+///
+/// Returns `Err(DuplicateAnchorError)` if any two headings share the same
+/// anchor ID, which would produce invalid HTML and broken navigation links.
+///
+/// # Arguments
+///
+/// * `headers` - Slice of extracted headers to validate
+///
+/// # Errors
+///
+/// Returns an error listing all duplicate anchor IDs found.
+pub fn validate_anchor_ids(
+  headers: &[Header],
+) -> Result<(), DuplicateAnchorError> {
+  use rustc_hash::FxHashMap;
+
+  let mut seen: FxHashMap<&str, (&str, u8)> = FxHashMap::default();
+  let mut duplicates = Vec::new();
+
+  for header in headers {
+    if let Some(&(first_text, first_level)) = seen.get(header.id.as_str()) {
+      duplicates.push(DuplicateAnchor {
+        id: header.id.clone(),
+        first_text: first_text.to_string(),
+        first_level,
+        second_text: header.text.clone(),
+        second_level: header.level,
+      });
+    } else {
+      seen.insert(&header.id, (&header.text, header.level));
+    }
+  }
+
+  if duplicates.is_empty() {
+    Ok(())
+  } else {
+    Err(DuplicateAnchorError { duplicates })
+  }
+}
+
 /// Result of Markdown processing.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct MarkdownResult {
@@ -35,4 +124,79 @@ pub struct MarkdownResult {
 
   /// Files that were included via `{=include=}` directives.
   pub included_files: Vec<IncludedFile>,
+}
+
+#[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "Fine in tests")]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn test_validate_anchor_ids_unique() {
+    let headers = vec![
+      Header {
+        text:  "First".to_string(),
+        level: 1,
+        id:    "first".to_string(),
+      },
+      Header {
+        text:  "Second".to_string(),
+        level: 2,
+        id:    "second".to_string(),
+      },
+    ];
+    assert!(validate_anchor_ids(&headers).is_ok());
+  }
+
+  #[test]
+  fn test_validate_anchor_ids_duplicate() {
+    let headers = vec![
+      Header {
+        text:  "First".to_string(),
+        level: 1,
+        id:    "same".to_string(),
+      },
+      Header {
+        text:  "Second".to_string(),
+        level: 2,
+        id:    "same".to_string(),
+      },
+    ];
+    let err = validate_anchor_ids(&headers).unwrap_err();
+    assert_eq!(err.duplicates.len(), 1);
+    assert_eq!(err.duplicates[0].id, "same");
+  }
+
+  #[test]
+  fn test_validate_anchor_ids_multiple_duplicates() {
+    let headers = vec![
+      Header {
+        text:  "A".to_string(),
+        level: 1,
+        id:    "x".to_string(),
+      },
+      Header {
+        text:  "B".to_string(),
+        level: 2,
+        id:    "x".to_string(),
+      },
+      Header {
+        text:  "C".to_string(),
+        level: 1,
+        id:    "y".to_string(),
+      },
+      Header {
+        text:  "D".to_string(),
+        level: 2,
+        id:    "y".to_string(),
+      },
+    ];
+    let err = validate_anchor_ids(&headers).unwrap_err();
+    assert_eq!(err.duplicates.len(), 2);
+  }
+
+  #[test]
+  fn test_validate_anchor_ids_empty() {
+    assert!(validate_anchor_ids(&[]).is_ok());
+  }
 }

--- a/ndg-commonmark/src/types.rs
+++ b/ndg-commonmark/src/types.rs
@@ -110,6 +110,54 @@ pub fn validate_anchor_ids(
   }
 }
 
+/// Validate that all IDs in rendered HTML are unique.
+pub(crate) fn validate_rendered_anchor_ids(
+  headers: &[Header],
+  html: &str,
+) -> Result<(), DuplicateAnchorError> {
+  validate_anchor_ids(headers)?;
+
+  let mut seen = rustc_hash::FxHashMap::default();
+  let mut duplicate_ids = Vec::new();
+  let mut rest = html;
+  while let Some(start) = rest.find("id=\"") {
+    rest = &rest[start + 4..];
+    let Some(end) = rest.find('"') else {
+      break;
+    };
+    let id = &rest[..end];
+    if seen.insert(id, ()).is_some()
+      && !duplicate_ids.iter().any(|seen| seen == id)
+    {
+      duplicate_ids.push(id.to_owned());
+    }
+    rest = &rest[end + 1..];
+  }
+
+  if duplicate_ids.is_empty() {
+    return Ok(());
+  }
+
+  let duplicates = duplicate_ids
+    .into_iter()
+    .map(|id| {
+      let heading = headers.iter().find(|header| header.id == id);
+      let (first_text, first_level) = heading
+        .map(|header| (header.text.clone(), header.level))
+        .unwrap_or_else(|| ("non-heading anchor".to_owned(), 0));
+      DuplicateAnchor {
+        id,
+        first_text,
+        first_level,
+        second_text: "non-heading anchor".to_owned(),
+        second_level: 0,
+      }
+    })
+    .collect();
+
+  Err(DuplicateAnchorError { duplicates })
+}
+
 /// Result of Markdown processing.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct MarkdownResult {

--- a/ndg-commonmark/tests/markup.rs
+++ b/ndg-commonmark/tests/markup.rs
@@ -295,6 +295,18 @@ fn test_mixed_explicit_and_auto_duplicate_ids_detected() {
 }
 
 #[test]
+fn test_duplicate_non_heading_anchor_ids_detected() {
+  let md = "## Introduction {#same-id}\n\n[]{#same-id}";
+  let options = ndg_commonmark::MarkdownOptions {
+    highlight_code: false,
+    ..Default::default()
+  };
+  let processor = ndg_commonmark::MarkdownProcessor::new(options);
+
+  assert!(processor.render_checked(md).is_err());
+}
+
+#[test]
 fn test_unique_anchor_ids_pass_validation() {
   let md = "## First {#first}\n\n## Second {#second}\n\n## Third";
   let options = ndg_commonmark::MarkdownOptions {

--- a/ndg-commonmark/tests/markup.rs
+++ b/ndg-commonmark/tests/markup.rs
@@ -242,6 +242,129 @@ fn test_setext_heading_with_explicit_anchor_keeps_level() {
   );
 }
 
+#[test]
+fn test_duplicate_explicit_anchor_ids_detected() {
+  let md = "## First {#same-id}\n\n## Second {#same-id}";
+  let options = ndg_commonmark::MarkdownOptions {
+    highlight_code: false,
+    ..Default::default()
+  };
+  let processor = ndg_commonmark::MarkdownProcessor::new(options);
+  let result = processor.render_checked(md);
+  assert!(result.is_err());
+  let err = result.unwrap_err();
+  let msg = err.to_string();
+  assert!(
+    msg.contains("same-id"),
+    "Error should mention the duplicate ID. Got:\n{msg}"
+  );
+  assert!(
+    msg.contains("First") && msg.contains("Second"),
+    "Error should mention both heading texts. Got:\n{msg}"
+  );
+}
+
+#[test]
+fn test_duplicate_auto_generated_anchor_ids_detected() {
+  let md = "## Installation\n\nSome text.\n\n## Installation";
+  let options = ndg_commonmark::MarkdownOptions {
+    highlight_code: false,
+    ..Default::default()
+  };
+  let processor = ndg_commonmark::MarkdownProcessor::new(options);
+  let result = processor.render_checked(md);
+  assert!(result.is_err());
+  let err = result.unwrap_err();
+  let msg = err.to_string();
+  assert!(
+    msg.contains("installation"),
+    "Error should mention the duplicate slug. Got:\n{msg}"
+  );
+}
+
+#[test]
+fn test_mixed_explicit_and_auto_duplicate_ids_detected() {
+  let md = "## Setup {#setup}\n\n## Setup";
+  let options = ndg_commonmark::MarkdownOptions {
+    highlight_code: false,
+    ..Default::default()
+  };
+  let processor = ndg_commonmark::MarkdownProcessor::new(options);
+  let result = processor.render_checked(md);
+  assert!(result.is_err());
+}
+
+#[test]
+fn test_unique_anchor_ids_pass_validation() {
+  let md = "## First {#first}\n\n## Second {#second}\n\n## Third";
+  let options = ndg_commonmark::MarkdownOptions {
+    highlight_code: false,
+    ..Default::default()
+  };
+  let processor = ndg_commonmark::MarkdownProcessor::new(options);
+  let result = processor.render_checked(md);
+  assert!(result.is_ok());
+}
+
+#[test]
+fn test_duplicate_anchor_ids_from_included_files() {
+  use std::fs;
+
+  use tempfile::tempdir;
+
+  let dir = tempdir().expect("create temp dir");
+  fs::write(
+    dir.path().join("included.md"),
+    "## Overview\n\nIncluded content.",
+  )
+  .expect("write included file");
+
+  let md = "## Overview\n\nMain content.\n\n```{=include=}\nincluded.md\n```";
+  let options = ndg_commonmark::MarkdownOptions {
+    nixpkgs: true,
+    highlight_code: false,
+    ..Default::default()
+  };
+  let processor =
+    ndg_commonmark::MarkdownProcessor::new(options).with_base_dir(dir.path());
+  let result = processor.render_checked(md);
+  assert!(result.is_err());
+  let err = result.unwrap_err();
+  let msg = err.to_string();
+  assert!(
+    msg.contains("overview"),
+    "Error should mention the duplicate slug from include. Got:\n{msg}"
+  );
+}
+
+#[test]
+fn test_auto_id_prefix_prevents_include_duplicates() {
+  use std::fs;
+
+  use tempfile::tempdir;
+
+  let dir = tempdir().expect("create temp dir");
+  fs::write(dir.path().join("a.md"), "## Overview\n\nFrom A.")
+    .expect("write file a");
+  fs::write(dir.path().join("b.md"), "## Overview\n\nFrom B.")
+    .expect("write file b");
+
+  let md = "```{=include=} auto-id-prefix=docs\na.md\nb.md\n```";
+  let options = ndg_commonmark::MarkdownOptions {
+    nixpkgs: true,
+    highlight_code: false,
+    ..Default::default()
+  };
+  let processor =
+    ndg_commonmark::MarkdownProcessor::new(options).with_base_dir(dir.path());
+  let result = processor.render_checked(md);
+  assert!(
+    result.is_ok(),
+    "auto-id-prefix with line numbers should prevent duplicates. Got:\n{}",
+    result.unwrap_err()
+  );
+}
+
 // Edge case: inline anchor at start of line
 #[test]
 fn test_inline_anchor_start_of_line() {


### PR DESCRIPTION
Conceptually similar to how nixos-render-docs does it, adapted to our own pipeline.