### PR TITLE
Allow configuring sidebar exclusions in the config file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,8 @@ changes.
 - Module option JSON now uses a shared typed `nixosOptionsDoc` parser across
   HTML, search, manpage, and PDF output. Option pages also render the upstream
   `relatedPackages` field.
+- Per-page table-of-contents entries can now be excluded by exact title or
+  regular expression with `[sidebar.toc]` and `[[sidebar.toc.exclude]]`.
 - Comrak Markdown syntax extensions are now configurable via the new
   `[markdown]` configuration section. Supports 24 extensions including tables,
   task lists, footnotes, strikethrough, math (code/dollar/LaTeX), alerts,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,11 @@ changes.
   `relatedPackages` field.
 - Per-page table-of-contents entries can now be excluded by exact title or
   regular expression with `[sidebar.toc]` and `[[sidebar.toc.exclude]]`.
+  Excluded headings are also ignored for duplicate anchor validation.
+- Duplicate heading anchors are now configurable with
+  `[anchor] on_duplicate = "error" | "warn" | "deduplicate"` (default
+  `"error"`). `"deduplicate"` makes IDs unique with deterministic `-1`, `-2`,
+  ... suffixes.
 - Comrak Markdown syntax extensions are now configurable via the new
   `[markdown]` configuration section. Supports 24 extensions including tables,
   task lists, footnotes, strikethrough, math (code/dollar/LaTeX), alerts,

--- a/crates/ndg-config/src/anchor.rs
+++ b/crates/ndg-config/src/anchor.rs
@@ -1,3 +1,5 @@
+use std::str::FromStr;
+
 use ndg_macros::Configurable;
 use serde::{Deserialize, Serialize};
 
@@ -9,4 +11,75 @@ pub struct AnchorConfig {
 
   #[config(key = "compatibility_anchors")]
   pub compatibility_anchors: bool,
+
+  /// How to handle duplicate heading anchor IDs within a single page.
+  #[config(key = "on_duplicate")]
+  pub on_duplicate: DuplicateAnchorPolicy,
+}
+
+/// Policy for duplicate heading anchor IDs within a single page.
+#[derive(
+  Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize,
+)]
+#[serde(rename_all = "lowercase")]
+pub enum DuplicateAnchorPolicy {
+  /// Fail the build on duplicate anchors (current behaviour).
+  #[default]
+  Error,
+  /// Log a warning and keep the duplicate IDs as-is.
+  Warn,
+  /// Make anchors unique with deterministic `-1`, `-2`, ... suffixes.
+  Deduplicate,
+}
+
+impl FromStr for DuplicateAnchorPolicy {
+  type Err = String;
+
+  fn from_str(s: &str) -> Result<Self, Self::Err> {
+    match s.to_lowercase().as_str() {
+      "error" => Ok(Self::Error),
+      "warn" => Ok(Self::Warn),
+      "deduplicate" => Ok(Self::Deduplicate),
+      _ => {
+        Err(format!(
+          "Unknown duplicate anchor policy: {s}; expected `error`, `warn`, or \
+           `deduplicate`"
+        ))
+      },
+    }
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  #![allow(clippy::unwrap_used, reason = "Fine in tests")]
+
+  use super::*;
+
+  #[test]
+  fn test_duplicate_policy_default_is_error() {
+    let config = AnchorConfig::default();
+    assert_eq!(config.on_duplicate, DuplicateAnchorPolicy::Error);
+  }
+
+  #[test]
+  fn test_duplicate_policy_toml_deserialization() {
+    let config: AnchorConfig =
+      toml::from_str("on_duplicate = \"warn\"").unwrap();
+    assert_eq!(config.on_duplicate, DuplicateAnchorPolicy::Warn);
+
+    let config: AnchorConfig =
+      toml::from_str("on_duplicate = \"deduplicate\"").unwrap();
+    assert_eq!(config.on_duplicate, DuplicateAnchorPolicy::Deduplicate);
+  }
+
+  #[test]
+  fn test_duplicate_policy_apply_override() {
+    let mut config = AnchorConfig::default();
+    config.apply_override("on_duplicate", "warn").unwrap();
+    assert_eq!(config.on_duplicate, DuplicateAnchorPolicy::Warn);
+
+    let err = config.apply_override("on_duplicate", "bogus").unwrap_err();
+    assert!(err.to_string().contains("Unknown duplicate anchor policy"));
+  }
 }

--- a/crates/ndg-config/src/config.rs
+++ b/crates/ndg-config/src/config.rs
@@ -259,6 +259,18 @@ impl Config {
       .is_some_and(|a| a.compatibility_anchors)
   }
 
+  /// Returns the configured duplicate heading anchor policy.
+  ///
+  /// Defaults to `Error` when no `anchor` configuration is present,
+  /// preserving the current fail-on-duplicate behaviour.
+  #[must_use]
+  pub fn duplicate_anchor_policy(&self) -> anchor::DuplicateAnchorPolicy {
+    self
+      .anchor
+      .as_ref()
+      .map_or(anchor::DuplicateAnchorPolicy::Error, |a| a.on_duplicate)
+  }
+
   /// Returns whether to use README.md as the homepage when index.md is not
   /// present.
   #[must_use]

--- a/crates/ndg-config/src/sidebar.rs
+++ b/crates/ndg-config/src/sidebar.rs
@@ -44,6 +44,10 @@ pub struct SidebarConfig {
   #[serde(default)]
   pub matches: Vec<SidebarMatch>,
 
+  /// Per-page table of contents configuration.
+  #[serde(default)]
+  pub toc: SidebarTocConfig,
+
   /// Options sidebar configuration.
   #[serde(default)]
   pub options: Option<OptionsConfig>,
@@ -68,6 +72,8 @@ impl SidebarConfig {
         .map_err(|e| format!("Sidebar match #{}: {}", idx + 1, e))?;
     }
 
+    self.toc.validate()?;
+
     // Validate and compile options config if present
     if let Some(ref mut options_config) = self.options {
       options_config.validate()?;
@@ -80,6 +86,39 @@ impl SidebarConfig {
   #[must_use]
   pub fn find_match(&self, path: &str, title: &str) -> Option<&SidebarMatch> {
     self.matches.iter().find(|m| m.matches(path, title))
+  }
+}
+
+/// Configuration for generated per-page tables of contents.
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
+pub struct SidebarTocConfig {
+  /// Heading titles to exclude from tables of contents.
+  #[serde(default)]
+  pub exclude: Vec<TitleMatch>,
+}
+
+impl SidebarTocConfig {
+  /// Validate and compile all exclusion regex patterns.
+  ///
+  /// # Errors
+  ///
+  /// Returns an error if any regex pattern is invalid.
+  pub fn validate(&mut self) -> Result<(), String> {
+    for (idx, title_match) in self.exclude.iter_mut().enumerate() {
+      title_match
+        .compile_regex()
+        .map_err(|e| format!("Sidebar TOC exclusion #{}: {e}", idx + 1))?;
+    }
+    Ok(())
+  }
+
+  /// Returns whether a heading title should be excluded.
+  #[must_use]
+  pub fn excludes(&self, title: &str) -> bool {
+    self
+      .exclude
+      .iter()
+      .any(|matcher| matcher.has_pattern() && matcher.matches(title))
   }
 }
 
@@ -229,6 +268,47 @@ impl MatchField for TitleMatch {
 }
 
 impl TitleMatch {
+  const fn has_pattern(&self) -> bool {
+    self.exact.is_some() || self.regex.is_some()
+  }
+
+  fn compile_regex(&mut self) -> Result<(), String> {
+    if let Some(ref pattern) = self.regex {
+      self.compiled_regex = Some(
+        Regex::new(pattern)
+          .map_err(|e| format!("Invalid title regex '{pattern}': {e}"))?,
+      );
+    }
+    Ok(())
+  }
+
+  /// Returns whether this matcher matches a title.
+  ///
+  /// # Panics
+  ///
+  /// Panics if a regex pattern has not been compiled by configuration
+  /// validation.
+  #[must_use]
+  fn matches(&self, title: &str) -> bool {
+    if self.exact.as_ref().is_some_and(|exact| title != exact) {
+      return false;
+    }
+
+    if self.regex.is_some() {
+      #[expect(
+        clippy::expect_used,
+        reason = "invariant guaranteed by configuration validation"
+      )]
+      return self
+        .compiled_regex
+        .as_ref()
+        .expect("internal error: invalid regex configuration")
+        .is_match(title);
+    }
+
+    true
+  }
+
   /// Create a new `TitleMatch` with exact matching.
   #[cfg(test)]
   #[must_use]
@@ -302,13 +382,8 @@ impl SidebarMatch {
       );
     }
 
-    if let Some(ref mut title_match) = self.title
-      && let Some(ref pattern) = title_match.regex
-    {
-      title_match.compiled_regex = Some(
-        Regex::new(pattern)
-          .map_err(|e| format!("Invalid title regex '{pattern}': {e}"))?,
-      );
+    if let Some(ref mut title_match) = self.title {
+      title_match.compile_regex()?;
     }
 
     Ok(())
@@ -356,28 +431,12 @@ impl SidebarMatch {
     }
 
     // Check title matching
-    if let Some(ref title_match) = self.title {
-      // Check exact title match
-      if let Some(ref exact_title) = title_match.exact
-        && title_str != exact_title
-      {
-        return false;
-      }
-
-      // Check regex title match
-      if let Some(ref _pattern) = title_match.regex {
-        #[expect(
-          clippy::expect_used,
-          reason = "invariant guaranteed during SidebarEntry construction"
-        )]
-        let re = title_match
-          .compiled_regex
-          .as_ref()
-          .expect("internal error: invalid regex configuration");
-        if !re.is_match(title_str) {
-          return false;
-        }
-      }
+    if self
+      .title
+      .as_ref()
+      .is_some_and(|title_match| !title_match.matches(title_str))
+    {
+      return false;
     }
 
     true
@@ -622,6 +681,7 @@ mod tests {
     assert!(!config.number_special_files);
     assert!(matches!(config.ordering, SidebarOrdering::Alphabetical));
     assert!(config.matches.is_empty());
+    assert!(config.toc.exclude.is_empty());
     assert!(config.options.is_none());
   }
 
@@ -732,6 +792,7 @@ mod tests {
       ordering:             SidebarOrdering::Custom,
       group_by_dir:         false,
       show_group_counts:    true,
+      toc:                  SidebarTocConfig::default(),
       options:              None,
       matches:              vec![
         SidebarMatch {
@@ -770,6 +831,7 @@ mod tests {
       ordering:             SidebarOrdering::Alphabetical,
       group_by_dir:         false,
       show_group_counts:    true,
+      toc:                  SidebarTocConfig::default(),
       options:              None,
       matches:              vec![
         SidebarMatch {
@@ -802,6 +864,7 @@ mod tests {
       ordering:             SidebarOrdering::Alphabetical,
       group_by_dir:         false,
       show_group_counts:    true,
+      toc:                  SidebarTocConfig::default(),
       options:              None,
       matches:              vec![SidebarMatch {
         path:      Some(PathMatch::exact("test.md".to_string())),
@@ -828,6 +891,7 @@ mod tests {
       ordering:             SidebarOrdering::Alphabetical,
       group_by_dir:         false,
       show_group_counts:    true,
+      toc:                  SidebarTocConfig::default(),
       options:              None,
       matches:              vec![SidebarMatch {
         path:      Some(PathMatch::exact("test.md".to_string())),
@@ -886,6 +950,23 @@ position = 50
       Some(r"^api/.*\.md$")
     );
     assert_eq!(config.matches[1].position, Some(50));
+  }
+
+  #[test]
+  fn test_sidebar_toc_rejects_invalid_exclusion_regex() {
+    let toml = r#"
+[toc]
+[[toc.exclude]]
+regex = "[invalid"
+"#;
+    let mut config: SidebarConfig =
+      toml::from_str(toml).expect("sidebar TOC config should deserialize");
+
+    let error = config
+      .validate()
+      .expect_err("invalid TOC exclusion regex should fail validation");
+    assert!(error.contains("Sidebar TOC exclusion #1"));
+    assert!(error.contains("Invalid title regex"));
   }
 
   #[test]

--- a/crates/ndg-config/src/templates.rs
+++ b/crates/ndg-config/src/templates.rs
@@ -81,6 +81,14 @@ highlight_code = true
 # How to handle hard tabs in code blocks (one of "none", "warn", or "normalize")
 tab_style = "none"
 
+# Duplicate heading anchor handling (one of "error", "warn", or "deduplicate")
+# - "error": fail the build on duplicate anchors (default)
+# - "warn": log a warning and keep duplicate IDs
+# - "deduplicate": make anchors unique with deterministic -1, -2, ... suffixes
+# Headings matching [sidebar.toc] exclusions are ignored for validation.
+# [anchor]
+# on_duplicate = "error"
+
 # GitHub revision for linking to source files (defaults to 'local')
 revision = "main"
 

--- a/crates/ndg-config/src/templates.rs
+++ b/crates/ndg-config/src/templates.rs
@@ -155,6 +155,11 @@ max_heading_level = 3
 # Ordering algorithm for sidebar items: "alphabetical", "custom", or "filesystem"
 # ordering = "alphabetical"
 
+# Exclude headings from generated per-page tables of contents.
+# [sidebar.toc]
+# [[sidebar.toc.exclude]]
+# regex = "^(Inputs|Type|Examples)$"
+
 # Pattern-based sidebar matching rules
 # Rules are evaluated in order, and the first matching rule is applied.
 # All specified conditions are expected to match.

--- a/crates/ndg-html/src/template.rs
+++ b/crates/ndg-html/src/template.rs
@@ -485,7 +485,12 @@ pub fn render(
   // Table of contents .
   // Suppressed when frontmatter sets `toc = false`.
   let toc = if frontmatter.is_none_or(|fm| fm.toc != Some(false)) {
-    generate_toc(headers)
+    generate_toc(headers.iter().filter(|header| {
+      config
+        .sidebar
+        .as_ref()
+        .is_none_or(|sidebar| !sidebar.toc.excludes(&header.text))
+    }))
   } else {
     String::new()
   };
@@ -1635,7 +1640,7 @@ fn generate_custom_scripts(
 }
 
 /// Generate table of contents from headers
-fn generate_toc(headers: &[Header]) -> String {
+fn generate_toc<'a>(headers: impl IntoIterator<Item = &'a Header>) -> String {
   let mut toc = String::new();
   let mut current_level = 0;
 
@@ -1680,7 +1685,7 @@ fn generate_toc(headers: &[Header]) -> String {
     toc.push_str("</li></ul>");
     current_level -= 1;
   }
-  if !headers.is_empty() && !toc.is_empty() && !toc.ends_with("</li>") {
+  if !toc.is_empty() && !toc.ends_with("</li>") {
     toc.push_str("</li>");
   }
 

--- a/crates/ndg-html/tests/html_template.rs
+++ b/crates/ndg-html/tests/html_template.rs
@@ -18,6 +18,8 @@ use ndg_config::{
     SidebarConfig,
     SidebarMatch,
     SidebarOrdering,
+    SidebarTocConfig,
+    TitleMatch,
   },
 };
 use ndg_html::{options::process_options, template};
@@ -578,6 +580,57 @@ fn render_page_with_headers_toc() {
 }
 
 #[test]
+fn render_page_toc_excludes_matching_headings() {
+  let mut config = minimal_config();
+  config.sidebar = Some(SidebarConfig {
+    toc: SidebarTocConfig {
+      exclude: vec![
+        TitleMatch {
+          exact:          None,
+          regex:          Some("^(Inputs|Type|Examples)$".to_string()),
+          compiled_regex: None,
+        },
+        TitleMatch::default(),
+      ],
+    },
+    ..Default::default()
+  });
+  config
+    .sidebar
+    .as_mut()
+    .expect("sidebar should be configured")
+    .validate()
+    .expect("TOC exclusion regex should be valid");
+  let headers = vec![
+    Header {
+      level: 1,
+      text:  "Inputs".to_string(),
+      id:    "inputs".to_string(),
+    },
+    Header {
+      level: 1,
+      text:  "Usage".to_string(),
+      id:    "usage".to_string(),
+    },
+  ];
+  let content = "<h1 id=\"inputs\">Inputs</h1><h1 id=\"usage\">Usage</h1>";
+
+  let html = template::render(
+    &config,
+    content,
+    "Test Page",
+    &headers,
+    Path::new("index.html"),
+    None,
+  )
+  .expect("Should render HTML");
+
+  assert!(!html.contains("href=\"#inputs\""));
+  assert!(html.contains("href=\"#usage\""));
+  assert!(html.contains("<h1 id=\"inputs\">Inputs</h1>"));
+}
+
+#[test]
 fn render_options_page_with_multiple_options() {
   let mut config = minimal_config();
   config.module_options = Some("dummy.json".into());
@@ -958,6 +1011,7 @@ fn sidebar_numbering_excludes_special_files() {
     group_by_dir:         false,
     show_group_counts:    true,
     matches:              vec![],
+    toc:                  SidebarTocConfig::default(),
     options:              None,
   });
 
@@ -1017,6 +1071,7 @@ fn sidebar_numbering_special_files_included() {
     group_by_dir:         false,
     show_group_counts:    true,
     matches:              vec![],
+    toc:                  SidebarTocConfig::default(),
     options:              None,
   });
 
@@ -1082,6 +1137,7 @@ fn sidebar_numbering_disabled_no_numbers() {
     group_by_dir:         false,
     show_group_counts:    true,
     matches:              vec![],
+    toc:                  SidebarTocConfig::default(),
     options:              None,
   });
 

--- a/crates/ndg-macros/src/lib.rs
+++ b/crates/ndg-macros/src/lib.rs
@@ -429,6 +429,16 @@ fn generate_value_assignment(
     };
   }
 
+  // DuplicateAnchorPolicy handling
+  if type_is(field_type, "DuplicateAnchorPolicy") {
+    return quote! {
+      self.#field_name = value.parse().map_err(|e: String| ConfigError::Config(format!(
+        "Invalid value for '{}': '{}' - {}",
+        stringify!(#field_name), value, e
+      )))?;
+    };
+  }
+
   // usize handling
   if type_is(field_type, "usize") {
     return quote! {

--- a/crates/ndg-utils/src/markdown.rs
+++ b/crates/ndg-utils/src/markdown.rs
@@ -12,9 +12,12 @@ use ndg_commonmark::{
   MarkdownOptionsBuilder,
   MarkdownProcessor,
   collect_markdown_files,
+  deduplicate_anchor_ids,
   processor::types::TabStyle,
+  validate_anchor_ids,
+  validate_rendered_anchor_ids,
 };
-use ndg_config::Config;
+use ndg_config::{Config, anchor::DuplicateAnchorPolicy};
 use rayon::prelude::*;
 use rustc_hash::{FxHashMap, FxHashSet};
 use serde::{Deserialize, Serialize};
@@ -268,16 +271,13 @@ fn process_markdown_files_impl(
         }
 
         let (frontmatter, content) = strip_frontmatter(&raw_content);
+        // Render without validation; duplicate-anchor policy (including
+        // `[sidebar.toc]` exclusions) is applied after cache lookup so cached
+        // and fresh renders behave identically.
         let result = base_processor
           .clone()
           .with_base_dir(base_dir)
-          .render_checked(&content)
-          .map_err(|e| {
-            color_eyre::eyre::eyre!(
-              "Duplicate anchor IDs in {}:\n{e}",
-              file_path.display()
-            )
-          })?;
+          .render(&content);
         if let Some((dir, processor_digest)) = &cache {
           write_cache(
             dir,
@@ -294,7 +294,13 @@ fn process_markdown_files_impl(
       .collect();
     progress.finish_with_message("Markdown processing complete");
 
-    let rendered = rendered?;
+    let mut rendered = rendered?;
+    // Apply duplicate-anchor policy per file. TOC-excluded headings are
+    // ignored for validation but keep their HTML IDs.
+    for (file_path, (_, result)) in files.iter().zip(rendered.iter_mut()) {
+      apply_anchor_policy(config, file_path, result)?;
+    }
+    let rendered = rendered;
     for (file_path, (_, result)) in files.iter().zip(&rendered) {
       let base_dir = file_path.parent().unwrap_or(input_dir.as_path());
 
@@ -441,6 +447,143 @@ fn process_markdown_files_impl(
   } else {
     info!("No input directory provided, skipping markdown processing");
     Ok(Vec::new())
+  }
+}
+
+/// Validate or deduplicate heading anchors for a single rendered page.
+///
+/// Headings matching `[sidebar.toc]` exclusions are ignored for duplicate
+/// validation but keep their HTML IDs. The configured
+/// `[anchor] on_duplicate` policy decides whether duplicates fail the build
+/// (`error`), log a warning (`warn`), or are made unique with `-1`, `-2`, ...
+/// suffixes (`deduplicate`).
+fn apply_anchor_policy(
+  config: &Config,
+  file_path: &Path,
+  result: &mut ndg_commonmark::MarkdownResult,
+) -> Result<()> {
+  let policy = config.duplicate_anchor_policy();
+  let has_excludes = config.sidebar.as_ref().is_some_and(|sidebar| {
+    !sidebar.toc.exclude.is_empty()
+      && result
+        .headers
+        .iter()
+        .any(|header| sidebar.toc.excludes(&header.text))
+  });
+
+  if !has_excludes {
+    match policy {
+      DuplicateAnchorPolicy::Error => {
+        validate_rendered_anchor_ids(&result.headers, &result.html).map_err(
+          |e| {
+            color_eyre::eyre::eyre!(
+              "Duplicate anchor IDs in {}:\n{e}",
+              file_path.display()
+            )
+          },
+        )?;
+        return Ok(());
+      },
+      DuplicateAnchorPolicy::Warn => {
+        if let Err(e) =
+          validate_rendered_anchor_ids(&result.headers, &result.html)
+        {
+          warn!("Duplicate anchor IDs in {}:\n{e}", file_path.display());
+        }
+        return Ok(());
+      },
+      DuplicateAnchorPolicy::Deduplicate => {
+        let renames =
+          deduplicate_anchor_ids(&mut result.headers, &mut result.html);
+        for (old, new) in &renames {
+          info!(
+            "Deduplicated anchor ID '{old}' -> '{new}' in {}",
+            file_path.display()
+          );
+        }
+        return Ok(());
+      },
+    }
+  }
+
+  // TOC exclusions present: validate only non-excluded headings, ignoring
+  // excluded IDs in the rendered HTML scan.
+  let Some(sidebar) = config.sidebar.as_ref() else {
+    return Ok(());
+  };
+  let excluded_ids: FxHashSet<String> = result
+    .headers
+    .iter()
+    .filter(|header| sidebar.toc.excludes(&header.text))
+    .map(|header| header.id.clone())
+    .collect();
+
+  let filtered: Vec<Header> = result
+    .headers
+    .iter()
+    .filter(|header| !sidebar.toc.excludes(&header.text))
+    .cloned()
+    .collect();
+
+  let validation = validate_anchor_ids(&filtered)
+    .map_err(|e| {
+      color_eyre::eyre::eyre!(
+        "Duplicate anchor IDs in {}:\n{e}",
+        file_path.display()
+      )
+    })
+    .and_then(|()| {
+      // Scan HTML for duplicates, ignoring excluded IDs.
+      let mut seen = FxHashSet::default();
+      let mut duplicate_ids = Vec::new();
+      let mut rest = result.html.as_str();
+      while let Some(start) = rest.find("id=\"") {
+        rest = &rest[start + 4..];
+        let Some(end) = rest.find('"') else {
+          break;
+        };
+        let id = &rest[..end];
+        if !id.is_empty()
+          && !excluded_ids.contains(id)
+          && !seen.insert(id.to_owned())
+          && !duplicate_ids.iter().any(|seen| seen == id)
+        {
+          duplicate_ids.push(id.to_owned());
+        }
+        rest = &rest[end + 1..];
+      }
+      if duplicate_ids.is_empty() {
+        Ok(())
+      } else {
+        Err(color_eyre::eyre::eyre!(
+          "Duplicate anchor IDs in {}: {}",
+          file_path.display(),
+          duplicate_ids.join(", ")
+        ))
+      }
+    });
+
+  match policy {
+    DuplicateAnchorPolicy::Error => validation,
+    DuplicateAnchorPolicy::Warn => {
+      if let Err(e) = validation {
+        warn!("{e:#}");
+      }
+      Ok(())
+    },
+    DuplicateAnchorPolicy::Deduplicate => {
+      if validation.is_err() {
+        let renames =
+          deduplicate_anchor_ids(&mut result.headers, &mut result.html);
+        for (old, new) in &renames {
+          info!(
+            "Deduplicated anchor ID '{old}' -> '{new}' in {}",
+            file_path.display()
+          );
+        }
+      }
+      Ok(())
+    },
   }
 }
 
@@ -886,5 +1029,191 @@ mod tests {
     };
 
     assert!(create_processor(&config, None).is_err());
+  }
+
+  fn duplicate_result() -> MarkdownResult {
+    MarkdownResult {
+      html:           "<h3 id=\"inputs\">Inputs</h3><h3 \
+                       id=\"inputs\">Inputs</h3>"
+        .to_string(),
+      headers:        vec![
+        Header {
+          text:  "Inputs".to_string(),
+          level: 3,
+          id:    "inputs".to_string(),
+        },
+        Header {
+          text:  "Inputs".to_string(),
+          level: 3,
+          id:    "inputs".to_string(),
+        },
+      ],
+      title:          None,
+      included_files: Vec::new(),
+    }
+  }
+
+  fn config_with_toc_exclude(policy: DuplicateAnchorPolicy) -> Config {
+    use ndg_config::{anchor::AnchorConfig, sidebar::SidebarTocConfig};
+    let mut sidebar = ndg_config::sidebar::SidebarConfig::default();
+    sidebar.toc = SidebarTocConfig {
+      exclude: vec![ndg_config::sidebar::TitleMatch {
+        exact:          None,
+        regex:          Some("^(Inputs|Type|Examples)$".to_string()),
+        compiled_regex: None,
+      }],
+    };
+    sidebar.validate().unwrap();
+    Config {
+      sidebar: Some(sidebar),
+      anchor: Some(AnchorConfig {
+        on_duplicate: policy,
+        ..Default::default()
+      }),
+      ..Config::default()
+    }
+  }
+
+  #[test]
+  fn toc_excluded_duplicates_pass_with_error_policy() {
+    let config = config_with_toc_exclude(DuplicateAnchorPolicy::Error);
+    let mut result = duplicate_result();
+    apply_anchor_policy(&config, Path::new("page.md"), &mut result).unwrap();
+  }
+
+  #[test]
+  fn non_excluded_duplicates_still_error() {
+    use ndg_config::sidebar::SidebarTocConfig;
+
+    let mut config = config_with_toc_exclude(DuplicateAnchorPolicy::Error);
+    // Only exclude "Examples", so "Inputs" duplicates must still fail.
+    let mut sidebar = config.sidebar.take().unwrap();
+    sidebar.toc = SidebarTocConfig {
+      exclude: vec![ndg_config::sidebar::TitleMatch {
+        exact:          Some("Examples".to_string()),
+        regex:          None,
+        compiled_regex: None,
+      }],
+    };
+    config.sidebar = Some(sidebar);
+    let mut result = duplicate_result();
+    assert!(
+      apply_anchor_policy(&config, Path::new("page.md"), &mut result).is_err()
+    );
+  }
+
+  #[test]
+  fn deduplicate_policy_makes_anchors_unique() {
+    let config = Config {
+      anchor: Some(ndg_config::anchor::AnchorConfig {
+        on_duplicate: DuplicateAnchorPolicy::Deduplicate,
+        ..Default::default()
+      }),
+      ..Config::default()
+    };
+    let mut result = duplicate_result();
+    apply_anchor_policy(&config, Path::new("page.md"), &mut result).unwrap();
+    assert_eq!(result.headers[0].id, "inputs");
+    assert_eq!(result.headers[1].id, "inputs-1");
+    assert!(result.html.contains("id=\"inputs-1\""));
+  }
+
+  #[test]
+  fn warn_policy_keeps_duplicates() {
+    let config = Config {
+      anchor: Some(ndg_config::anchor::AnchorConfig {
+        on_duplicate: DuplicateAnchorPolicy::Warn,
+        ..Default::default()
+      }),
+      ..Config::default()
+    };
+    let mut result = duplicate_result();
+    apply_anchor_policy(&config, Path::new("page.md"), &mut result).unwrap();
+    assert_eq!(result.headers[1].id, "inputs");
+  }
+
+  /// Replicates <https://github.com/feel-co/ndg/issues/272#issuecomment-5476940549>:
+  /// repeated `Inputs`/`Type`/`Examples` sections must fail by default, pass
+  /// when excluded from the TOC, and pass under `warn`/`deduplicate` policies.
+  #[test]
+  fn issue_272_duplicate_sections_end_to_end() {
+    use ndg_config::anchor::AnchorConfig;
+
+    const DOC: &str = "# Module\n\n### Inputs\n\nFirst.\n\n### \
+                       Type\n\nSecond.\n\n### Examples\n\nThird.\n\n### \
+                       Inputs\n\nFourth.\n\n### Type\n\nFifth.\n\n### \
+                       Examples\n\nSixth.\n";
+
+    fn run(
+      policy: Option<DuplicateAnchorPolicy>,
+      exclude: bool,
+    ) -> Result<usize> {
+      let temp = TempDir::new().unwrap();
+      let input = temp.path().join("docs");
+      fs::create_dir_all(&input).unwrap();
+      fs::write(input.join("module-schema.md"), DOC).unwrap();
+      let mut config = Config {
+        input_dir: Some(input),
+        anchor: policy.map(|on_duplicate| {
+          AnchorConfig {
+            on_duplicate,
+            ..Default::default()
+          }
+        }),
+        ..Config::default()
+      };
+      if exclude {
+        use ndg_config::sidebar::SidebarTocConfig;
+        let mut sidebar = ndg_config::sidebar::SidebarConfig::default();
+        sidebar.toc = SidebarTocConfig {
+          exclude: vec![ndg_config::sidebar::TitleMatch {
+            exact:          None,
+            regex:          Some("^(Inputs|Type|Examples)$".to_string()),
+            compiled_regex: None,
+          }],
+        };
+        sidebar.validate().unwrap();
+        config.sidebar = Some(sidebar);
+      }
+      process_markdown_files(&mut config, None)
+        .map(|pages| pages.iter().map(|page| page.headers.len()).sum())
+    }
+
+    assert!(run(None, false).is_err(), "duplicates must fail by default");
+    assert_eq!(
+      run(None, true).unwrap(),
+      7,
+      "TOC-excluded duplicates must no longer fail"
+    );
+    assert!(run(Some(DuplicateAnchorPolicy::Warn), false).is_ok());
+    let pages = {
+      let temp = TempDir::new().unwrap();
+      let input = temp.path().join("docs");
+      fs::create_dir_all(&input).unwrap();
+      fs::write(input.join("module-schema.md"), DOC).unwrap();
+      let mut config = Config {
+        input_dir: Some(input),
+        anchor: Some(AnchorConfig {
+          on_duplicate: DuplicateAnchorPolicy::Deduplicate,
+          ..Default::default()
+        }),
+        ..Config::default()
+      };
+      process_markdown_files(&mut config, None).unwrap()
+    };
+    let ids: Vec<&str> = pages[0]
+      .headers
+      .iter()
+      .map(|header| header.id.as_str())
+      .collect();
+    assert_eq!(ids, vec![
+      "module",
+      "inputs",
+      "type",
+      "examples",
+      "inputs-1",
+      "type-1",
+      "examples-1"
+    ]);
   }
 }

--- a/ndg-commonmark/src/lib.rs
+++ b/ndg-commonmark/src/lib.rs
@@ -152,7 +152,9 @@ pub use crate::{
     Header,
     IncludedFile,
     MarkdownResult,
+    deduplicate_anchor_ids,
     validate_anchor_ids,
+    validate_rendered_anchor_ids,
   },
   utils::ManpageUrlsError,
 };

--- a/ndg-commonmark/src/types.rs
+++ b/ndg-commonmark/src/types.rs
@@ -69,6 +69,108 @@ impl std::fmt::Display for DuplicateAnchorError {
 
 impl std::error::Error for DuplicateAnchorError {}
 
+/// Make all heading anchor IDs unique with deterministic `-1`, `-2`, etc.
+/// suffixes.
+///
+/// The first occurrence of an ID is kept as-is; subsequent occurrences get
+/// `"{id}-1"`, `"{id}-2"`, and so on (skipping IDs that already exist, e.g. an
+/// author-written `{#inputs-1}`). Empty IDs are ignored.
+///
+/// Both `headers` and the `id="..."` attributes in `html` are rewritten in
+/// document order so they stay in sync. Any remaining duplicate non-heading
+/// IDs in `html` are deduplicated with the same scheme.
+///
+/// Returns a list of `(old_id, new_id)` renames for logging.
+pub fn deduplicate_anchor_ids(
+  headers: &mut [Header],
+  html: &mut String,
+) -> Vec<(String, String)> {
+  use rustc_hash::{FxHashMap, FxHashSet};
+
+  let mut used: FxHashSet<String> = FxHashSet::default();
+  let mut next_suffix: FxHashMap<String, usize> = FxHashMap::default();
+  // (old_id, occurrence_index) -> new_id, to keep headers and HTML in sync.
+  let mut mapping: FxHashMap<(String, usize), String> = FxHashMap::default();
+  let mut header_occ: FxHashMap<String, usize> = FxHashMap::default();
+  let mut renames = Vec::new();
+
+  for header in headers.iter_mut() {
+    if header.id.is_empty() {
+      continue;
+    }
+    let old = header.id.clone();
+    let occ = header_occ.get(&old).copied().unwrap_or(0);
+    header_occ.insert(old.clone(), occ + 1);
+
+    if !used.contains(&old) {
+      used.insert(old.clone());
+      next_suffix.entry(old.clone()).or_insert(1);
+      mapping.insert((old.clone(), occ), old);
+      continue;
+    }
+
+    let mut suffix = next_suffix.get(&old).copied().unwrap_or(1);
+    let new_id = loop {
+      let candidate = format!("{old}-{suffix}");
+      suffix += 1;
+      if !used.contains(&candidate) {
+        break candidate;
+      }
+    };
+    next_suffix.insert(old.clone(), suffix);
+    used.insert(new_id.clone());
+    mapping.insert((old.clone(), occ), new_id.clone());
+    renames.push((old, new_id.clone()));
+    header.id = new_id;
+  }
+
+  // Rewrite `id="..."` attributes in document order to match the header
+  // mapping. IDs not present in the mapping (e.g. syntax-highlight extras)
+  // are deduplicated globally with the same suffix scheme.
+  let mut html_occ: FxHashMap<String, usize> = FxHashMap::default();
+  let mut result = String::with_capacity(html.len());
+  let mut rest = html.as_str();
+  while let Some(start) = rest.find("id=\"") {
+    result.push_str(&rest[..start + 4]);
+    rest = &rest[start + 4..];
+    let Some(end) = rest.find('"') else {
+      result.push_str(rest);
+      rest = "";
+      break;
+    };
+    let old = &rest[..end];
+    let occ = html_occ.get(old).copied().unwrap_or(0);
+    html_occ.insert(old.to_owned(), occ + 1);
+
+    if let Some(mapped) = mapping.get(&(old.to_owned(), occ)) {
+      result.push_str(mapped);
+    } else if used.contains(old) {
+      // Extra HTML-only duplicate: find the next free suffix.
+      let mut suffix = next_suffix.get(old).copied().unwrap_or(1);
+      let new_id = loop {
+        let candidate = format!("{old}-{suffix}");
+        suffix += 1;
+        if !used.contains(&candidate) {
+          break candidate;
+        }
+      };
+      next_suffix.insert(old.to_owned(), suffix);
+      used.insert(new_id.clone());
+      renames.push((old.to_owned(), new_id.clone()));
+      result.push_str(&new_id);
+    } else {
+      used.insert(old.to_owned());
+      next_suffix.entry(old.to_owned()).or_insert(1);
+      result.push_str(old);
+    }
+    rest = &rest[end..];
+  }
+  result.push_str(rest);
+  *html = result;
+
+  renames
+}
+
 /// Validate that all heading anchor IDs are unique.
 ///
 /// Returns `Err(DuplicateAnchorError)` if any two headings share the same
@@ -111,7 +213,11 @@ pub fn validate_anchor_ids(
 }
 
 /// Validate that all IDs in rendered HTML are unique.
-pub(crate) fn validate_rendered_anchor_ids(
+///
+/// # Errors
+///
+/// Returns an error listing all duplicate anchor IDs found.
+pub fn validate_rendered_anchor_ids(
   headers: &[Header],
   html: &str,
 ) -> Result<(), DuplicateAnchorError> {
@@ -245,5 +351,71 @@ mod tests {
   #[test]
   fn test_validate_anchor_ids_empty() {
     assert!(validate_anchor_ids(&[]).is_ok());
+  }
+
+  #[test]
+  fn test_deduplicate_anchor_ids_suffixes() {
+    let mut headers = vec![
+      Header {
+        text:  "Inputs".to_string(),
+        level: 3,
+        id:    "inputs".to_string(),
+      },
+      Header {
+        text:  "Inputs".to_string(),
+        level: 3,
+        id:    "inputs".to_string(),
+      },
+      Header {
+        text:  "Type".to_string(),
+        level: 3,
+        id:    "type".to_string(),
+      },
+    ];
+    let mut html = String::from(
+      "<h3 id=\"inputs\">Inputs</h3><h3 id=\"inputs\">Inputs</h3><h3 \
+       id=\"type\">Type</h3>",
+    );
+
+    let renames = deduplicate_anchor_ids(&mut headers, &mut html);
+    assert_eq!(headers[0].id, "inputs");
+    assert_eq!(headers[1].id, "inputs-1");
+    assert_eq!(headers[2].id, "type");
+    assert!(html.contains("id=\"inputs-1\""));
+    assert_eq!(renames, vec![(
+      "inputs".to_string(),
+      "inputs-1".to_string()
+    )]);
+    assert!(validate_anchor_ids(&headers).is_ok());
+    assert!(validate_rendered_anchor_ids(&headers, &html).is_ok());
+  }
+
+  #[test]
+  fn test_deduplicate_skips_existing_suffixed_id() {
+    let mut headers = vec![
+      Header {
+        text:  "A".to_string(),
+        level: 2,
+        id:    "x".to_string(),
+      },
+      Header {
+        text:  "B".to_string(),
+        level: 2,
+        id:    "x-1".to_string(),
+      },
+      Header {
+        text:  "C".to_string(),
+        level: 2,
+        id:    "x".to_string(),
+      },
+    ];
+    let mut html = String::from(
+      "<h2 id=\"x\">A</h2><h2 id=\"x-1\">B</h2><h2 id=\"x\">C</h2>",
+    );
+
+    deduplicate_anchor_ids(&mut headers, &mut html);
+    // Third header must skip the taken `x-1` and become `x-2`.
+    assert_eq!(headers[2].id, "x-2");
+    assert!(html.contains("id=\"x-2\""));
   }
 }

--- a/ndg/docs/SIDEBAR.md
+++ b/ndg/docs/SIDEBAR.md
@@ -112,6 +112,11 @@ their content remain in the rendered page. Exclusion entries use the same title
 matcher semantics as `sidebar.matches`: `exact` and `regex` are both supported,
 and both must match when specified together.
 
+Excluded headings are also ignored for duplicate anchor validation, so repeated
+section titles like `Inputs`, `Type`, or `Examples` no longer fail the build
+when excluded. Use `[anchor] on_duplicate = "warn"` or `"deduplicate"` to
+configure handling for remaining duplicates.
+
 ## Pattern Matching
 
 The `matches` array contains pattern-based rules for customizing specific

--- a/ndg/docs/SIDEBAR.md
+++ b/ndg/docs/SIDEBAR.md
@@ -20,6 +20,9 @@ ordering = "alphabetical"
 [[sidebar.matches]]
 # Pattern-based matching rules
 
+[sidebar.toc]
+# Per-page table of contents configuration
+
 [sidebar.options]
 # NixOS options-specific configuration
 ```
@@ -87,6 +90,27 @@ Determines how sidebar items are sorted.
   - `"alphabetical"` - Sort items alphabetically by title
   - `"filesystem"` - Preserve filesystem order
   - `"custom"` - Sort by the `position` field from pattern matches
+
+## Page Table of Contents
+
+The `sidebar.toc` section controls the generated per-page table of contents used
+by both the sidebar Contents section and the desktop On this page navigation.
+Use `exclude` entries to omit headings by exact title or regular expression.
+
+```toml
+[sidebar.toc]
+
+[[sidebar.toc.exclude]]
+exact = "Internal details"
+
+[[sidebar.toc.exclude]]
+regex = "^(Inputs|Type|Examples)$"
+```
+
+Exclusions only remove matching headings from the navigation; the headings and
+their content remain in the rendered page. Exclusion entries use the same title
+matcher semantics as `sidebar.matches`: `exact` and `regex` are both supported,
+and both must match when specified together.
 
 ## Pattern Matching
 

--- a/ndg/tests/integration.rs
+++ b/ndg/tests/integration.rs
@@ -221,6 +221,7 @@ fn test_sidebar_integration() {
     group_by_dir:         false,
     show_group_counts:    true,
     matches:              vec![],
+    toc:                  Default::default(),
     options:              None,
   };
 
@@ -283,6 +284,7 @@ fn test_sidebar_integration() {
         position:  Some(2),
       },
     ],
+    toc:                  Default::default(),
     options:              None,
   };
 
@@ -330,6 +332,7 @@ fn test_sidebar_integration() {
       new_title: Some("📖 Guide".to_string()),
       position:  None,
     }],
+    toc:                  Default::default(),
     options:              None,
   };
 


### PR DESCRIPTION
Depends on #274 

Introduces a new `[sidebar.toc]` config field that allows users to exclude specific headings from the per-page table of contents using exact title matches or regular expressions.